### PR TITLE
Minor CI cleanup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: Zaplib Continuous Integration
+name: CI
 on: [push]
 jobs:
   build_web_ci:
@@ -6,62 +6,54 @@ jobs:
     container:
       image: janpaul123/zaplib-ci@sha256:0bbef21ebbbdcdd42c46e85118bcddb2a9b668eb9cb027d46f96989b97117baf
     steps:
-      - name: Git checkout
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
       - run: zaplib/scripts/ci/build_web_ci.sh
   checks_for_all_targets_debug:
     runs-on: ubuntu-latest
     container:
       image: janpaul123/zaplib-ci@sha256:0bbef21ebbbdcdd42c46e85118bcddb2a9b668eb9cb027d46f96989b97117baf
     steps:
-      - name: Git checkout
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
       - run: zaplib/scripts/ci/checks_for_all_targets_debug.sh
   checks_for_all_targets_release:
     runs-on: ubuntu-latest
     container:
       image: janpaul123/zaplib-ci@sha256:0bbef21ebbbdcdd42c46e85118bcddb2a9b668eb9cb027d46f96989b97117baf
     steps:
-      - name: Git checkout
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
       - run: zaplib/scripts/ci/checks_for_all_targets_release.sh
   debug_builds:
     runs-on: ubuntu-latest
     container:
       image: janpaul123/zaplib-ci@sha256:0bbef21ebbbdcdd42c46e85118bcddb2a9b668eb9cb027d46f96989b97117baf
     steps:
-      - name: Git checkout
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
       - run: zaplib/scripts/ci/debug_builds.sh
   lint:
     runs-on: ubuntu-latest
     container:
       image: janpaul123/zaplib-ci@sha256:0bbef21ebbbdcdd42c46e85118bcddb2a9b668eb9cb027d46f96989b97117baf
     steps:
-      - name: Git checkout
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
       - run: zaplib/scripts/ci/lint.sh
   release_builds:
     runs-on: ubuntu-latest
     container:
       image: janpaul123/zaplib-ci@sha256:0bbef21ebbbdcdd42c46e85118bcddb2a9b668eb9cb027d46f96989b97117baf
     steps:
-      - name: Git checkout
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
       - run: zaplib/scripts/ci/release_builds.sh
   rust_nightly_build:
     runs-on: ubuntu-latest
     container:
       image: janpaul123/zaplib-ci@sha256:0bbef21ebbbdcdd42c46e85118bcddb2a9b668eb9cb027d46f96989b97117baf
     steps:
-      - name: Git checkout
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
       - run: zaplib/scripts/ci/rust_nightly_build.sh
   tests:
     runs-on: ubuntu-latest
     container:
       image: janpaul123/zaplib-ci@sha256:0bbef21ebbbdcdd42c46e85118bcddb2a9b668eb9cb027d46f96989b97117baf
     steps:
-      - name: Git checkout
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
       - run: zaplib/scripts/ci/tests.sh


### PR DESCRIPTION
Shorten the name of the suite so the checks are easier to read.

Remove unnecessary names in steps.