### PR TITLE
Fix error reporting race condition

### DIFF
--- a/zaplib/web/main_worker.ts
+++ b/zaplib/web/main_worker.ts
@@ -250,13 +250,13 @@ export class WasmApp {
       bindMainWorkerPort(port);
     });
 
+    Atomics.store(wasmOnline, 0, 1);
+    this.exports = wrapWasmExports(this.exports);
+
+    rpc.send(WorkerEvent.RemoveLoadingIndicators);
+
     // create initial zerdeEventloopEvents
     this.zerdeEventloopEvents = new ZerdeEventloopEvents(this);
-    this.initApp();
-    this.exports = wrapWasmExports(this.exports);
-  }
-
-  private initApp(): void {
     // initialize the application
     this.zerdeEventloopEvents.init({
       width: this.sizingData.width,
@@ -267,8 +267,6 @@ export class WasmApp {
       xrIsPresenting: false,
     });
     this.doWasmIo();
-
-    rpc.send(WorkerEvent.RemoveLoadingIndicators);
   }
 
   private doWasmIo(): void {

--- a/zaplib/web/wasm_runtime.ts
+++ b/zaplib/web/wasm_runtime.ts
@@ -747,7 +747,6 @@ export const initialize: Initialize = (initParams) => {
             offscreenCanvas ? [offscreenCanvas] : []
           )
           .then(() => {
-            Atomics.store(wasmOnline, 0, 1);
             canvasData.onScreenResize();
             resolve();
           });


### PR DESCRIPTION
We would set `wasmOnline` to 1 after we’d call `doWasm`; which would
occasionally cause an error.

Tested manually with `tutorial_3d_rendering_step_2`, but will be better
covered in CI when we do #29.

Regression caused during work on #13.