### PR TITLE
Allow initializing Zaplib without a canvas or with your own canvas

### DIFF
--- a/zaplib/docs/src/SUMMARY.md
+++ b/zaplib/docs/src/SUMMARY.md
@@ -21,6 +21,7 @@
 - [Tutorial: Rendering 2D Shapes](./tutorial_2d_rendering.md)
 - [Tutorial: Rendering 3D Meshes](./tutorial_3d_rendering.md)
 - [API Overview](./rendering_api_overview.md)
+  - [Canvas](./rendering_api_canvas.md)
   - [Rendering model](./rendering_api_overview_model.md)
   - [Events](./rendering_api_events_overview.md)
   - [Geometry](./rendering_api_overview_geometry.md)

--- a/zaplib/docs/src/bridge_api_basics.md
+++ b/zaplib/docs/src/bridge_api_basics.md
@@ -14,8 +14,9 @@ This initializes the library. A couple of things happen:
 
 | Parameter (Typescript)                      | Description |
 |---------------------------------------------|---------|
-| `initParams.filename: string`                          | Path to the `.wasm` file. During development, typically something like `/target/wasm32-unknown-unknown/debug/my_package_name.wasm`. |
-| `initParams.defaultStyles?: boolean`                   | Whether to inject some default styles, including a loading indicator. Useful for examples / getting started.     |
+| `initParams.filename: string` | Path to the `.wasm` file. During development, typically something like `/target/wasm32-unknown-unknown/debug/my_package_name.wasm`. |
+| `initParams.defaultStyles?: boolean` | Whether to inject some default styles, including a loading indicator and a canvas. Useful for examples / getting started. |
+| `initParams.canvas?: HTMLCanvasElement` | A `<canvas>` element that must span the whole page. If not given, then rendering isn't possible. `defaultStyles: true` will automatically create this and add it to `<body>`. See also the [Canvas page](./rendering_api_canvas.md). |
 
 <p></p>
 

--- a/zaplib/docs/src/rendering_api_canvas.md
+++ b/zaplib/docs/src/rendering_api_canvas.md
@@ -8,6 +8,11 @@ On the web, we need a `<canvas>` element somewhere to draw on. Currently, this e
 
 You can specify the canvas in a few ways:
 1. Use `zaplib.initialize({ defaultStyles: true })`, which automatically adds a canvas to the body of the page.
-2. Pass it in using `zaplib.initialize({ canvas })`. In this case some styles will automatically be applied to the canvas (through the `zaplib_canvas` CSS class), but you can override these yourself.
+2. Pass it in using `zaplib.initialize({ canvas })`. In this case some styles will automatically be applied to the canvas (through the `zaplib_canvas` CSS class), but you can override these yourself. For example:
+```js
+const canvas = document.createElement("canvas");
+document.body.appendChild(canvas);
+zaplib.initialize({ canvas });
+```
 
-Interoperation with existing DOM elements is still limited, but it is possible to add `id="zaplib_js_root"` to the root element that contains your other DOM elements in order to prevent Zaplib from handling events that are already captured by your application.
+Interoperation with existing DOM elements is still limited, but it is possible to add `id="zaplib_js_root"` to the root element that contains your other DOM elements in order to prevent Zaplib from handling events that are already captured by your JS code.

--- a/zaplib/docs/src/rendering_api_canvas.md
+++ b/zaplib/docs/src/rendering_api_canvas.md
@@ -1,0 +1,13 @@
+# Canvas
+
+On the web, we need a `<canvas>` element somewhere to draw on. Currently, this element must have the following properties:
+1. Span the entire page (absolutely positioned).
+2. Not used for any other rendering.
+3. There can only be one such canvas.
+4. It may be layered at any z-index: either behind other elements, on top of it, or in the middle (e.g. behind buttons and popovers, but in front of backgrounds).
+
+You can specify the canvas in a few ways:
+1. Use `zaplib.initialize({ defaultStyles: true })`, which automatically adds a canvas to the body of the page.
+2. Pass it in using `zaplib.initialize({ canvas })`. In this case some styles will automatically be applied to the canvas (through the `zaplib_canvas` CSS class), but you can override these yourself.
+
+Interoperation with existing DOM elements is still limited, but it is possible to add `id="zaplib_js_root"` to the root element that contains your other DOM elements in order to prevent Zaplib from handling events that are already captured by your application.

--- a/zaplib/web/rpc_types.ts
+++ b/zaplib/web/rpc_types.ts
@@ -121,7 +121,7 @@ export type WasmWorkerRpc = {
     [WorkerEvent.Init]: [
       {
         wasmModule: WebAssembly.Module;
-        offscreenCanvas: OffscreenCanvas;
+        offscreenCanvas: OffscreenCanvas | undefined;
         sizingData: SizingData;
         baseUri: string;
         memory: WebAssembly.Memory;

--- a/zaplib/web/types.ts
+++ b/zaplib/web/types.ts
@@ -1,5 +1,6 @@
 export type Initialize = (initParams: {
   filename: string;
+  canvas?: HTMLCanvasElement;
   baseUri?: string;
   defaultStyles?: boolean;
 }) => Promise<void>;


### PR DESCRIPTION
This is helpful for when using Zaplib for pure computation: #20 and #18.

It’s also a first step toward giving users more control over how
rendering works exactly (e.g. multiple canvases; different layering;
etc).

Tested with manually `tutorial_3d_rendering_step_2` which does pure
computation. Will be better covered in CI when we do #29.

Also added a bunch of docs.

Closes #20.