### PR TITLE
Suppress dynamic import warnings coming from vendor/web-worker/node.js

### DIFF
--- a/zaplib/web/package.json
+++ b/zaplib/web/package.json
@@ -26,6 +26,7 @@
         "typescript": "^4.4.3",
         "webpack": "^5.57.1",
         "webpack-cli": "^4.8.0",
+        "webpack-filter-warnings-plugin": "^1.2.1",
         "worker-loader": "^3.0.8"
     },
     "scripts": {

--- a/zaplib/web/webpack.config.js
+++ b/zaplib/web/webpack.config.js
@@ -3,6 +3,8 @@
 
 const path = require("path");
 
+const FilterWarningsPlugin = require("webpack-filter-warnings-plugin");
+
 // TODO(Paras): Export type definitions for our library builds, both for TypeScript
 // and potentially Flow, using something like https://github.com/joarwilk/flowgen.
 
@@ -92,6 +94,14 @@ const nodeJsConfig = (env, argv) => {
       // helps in debugging.
       chunkIds: "named",
     },
+    plugins: [
+      new FilterWarningsPlugin({
+        // Suppress warnings coming from ./vendor/web-worker/node.js as this is expected
+        // We are dynamically importing worker scripts
+        exclude:
+          /Critical dependency: the request of a dependency is an expression/,
+      }),
+    ],
   };
 };
 

--- a/zaplib/web/yarn.lock
+++ b/zaplib/web/yarn.lock
@@ -3566,6 +3566,11 @@ webpack-cli@^4.8.0:
     rechoir "^0.7.0"
     webpack-merge "^5.7.3"
 
+webpack-filter-warnings-plugin@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/webpack-filter-warnings-plugin/-/webpack-filter-warnings-plugin-1.2.1.tgz#dc61521cf4f9b4a336fbc89108a75ae1da951cdb"
+  integrity sha512-Ez6ytc9IseDMLPo0qCuNNYzgtUl8NovOqjIq4uAU8LTD4uoa1w1KpZyyzFtLTEMZpkkOkLfL9eN+KGYdk1Qtwg==
+
 webpack-merge@^5.7.3:
   version "5.8.0"
   resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-5.8.0.tgz#2b39dbf22af87776ad744c390223731d30a68f61"


### PR DESCRIPTION
See title.
Error message:
```
WARNING in ./vendor/web-worker/node.js 198:4-15
Critical dependency: the request of a dependency is an expression
 @ ./zaplib_nodejs_polyfill.ts 5:0-46 6:14-20

WARNING in ./vendor/web-worker/node.js 215:8-20
Critical dependency: the request of a dependency is an expression
 @ ./zaplib_nodejs_polyfill.ts 5:0-46 6:14-20
```