### PR TITLE
Throw an error for Worker polyfill when url is undefined

### DIFF
--- a/zaplib/web/jest/worker.test.js
+++ b/zaplib/web/jest/worker.test.js
@@ -30,3 +30,9 @@ test("initializes zaplib and calls rust", async () => {
   const [result] = await zaplib.callRust("total_sum", [data]);
   expect(result).toBe("36");
 });
+
+test("creates work with undefined url", () => {
+  expect( () => {
+    const worker = new Worker(undefined);
+  }).toThrow("Creating worker with undefined url");
+});

--- a/zaplib/web/package.json
+++ b/zaplib/web/package.json
@@ -26,7 +26,6 @@
         "typescript": "^4.4.3",
         "webpack": "^5.57.1",
         "webpack-cli": "^4.8.0",
-        "webpack-filter-warnings-plugin": "^1.2.1",
         "worker-loader": "^3.0.8"
     },
     "scripts": {

--- a/zaplib/web/vendor/web-worker/node.js
+++ b/zaplib/web/vendor/web-worker/node.js
@@ -200,7 +200,9 @@ function workerThread() {
   const isDataUrl = /^data:/.test(mod);
 
   if (type === "module") {
-    import(mod)
+    // Using eval trick here to prevent webpack warnings:
+    // "Critical dependency: the request of a dependency is an expression"
+    eval('import')(mod)
       .catch((err) => {
         if (isDataUrl && err.message === "Not supported") {
           console.warn(
@@ -217,7 +219,9 @@ function workerThread() {
       if (/^data:/.test(mod)) {
         evaluateDataUrl(mod, name);
       } else {
-        require(mod);
+        // Using eval trick here to prevent webpack warnings:
+        // "Critical dependency: the request of a dependency is an expression"
+        eval('require')(mod);
       }
     } catch (err) {
       console.error(err);

--- a/zaplib/web/vendor/web-worker/node.js
+++ b/zaplib/web/vendor/web-worker/node.js
@@ -92,6 +92,11 @@ function mainThread() {
    */
   class Worker extends EventTarget {
     constructor(url, options) {
+      // Webpack relies on Worker constructor to throw an error when passing undefined url
+      // This polyfill must match this behavior.
+      if (url === undefined) {
+        throw new Error("Creating worker with undefined url");
+      }
       super();
       const { name, type } = options || {};
       url += "";

--- a/zaplib/web/webpack.config.js
+++ b/zaplib/web/webpack.config.js
@@ -3,8 +3,6 @@
 
 const path = require("path");
 
-const FilterWarningsPlugin = require("webpack-filter-warnings-plugin");
-
 // TODO(Paras): Export type definitions for our library builds, both for TypeScript
 // and potentially Flow, using something like https://github.com/joarwilk/flowgen.
 
@@ -94,14 +92,6 @@ const nodeJsConfig = (env, argv) => {
       // helps in debugging.
       chunkIds: "named",
     },
-    plugins: [
-      new FilterWarningsPlugin({
-        // Suppress warnings coming from ./vendor/web-worker/node.js as this is expected
-        // We are dynamically importing worker scripts
-        exclude:
-          /Critical dependency: the request of a dependency is an expression/,
-      }),
-    ],
   };
 };
 

--- a/zaplib/web/yarn.lock
+++ b/zaplib/web/yarn.lock
@@ -3566,11 +3566,6 @@ webpack-cli@^4.8.0:
     rechoir "^0.7.0"
     webpack-merge "^5.7.3"
 
-webpack-filter-warnings-plugin@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/webpack-filter-warnings-plugin/-/webpack-filter-warnings-plugin-1.2.1.tgz#dc61521cf4f9b4a336fbc89108a75ae1da951cdb"
-  integrity sha512-Ez6ytc9IseDMLPo0qCuNNYzgtUl8NovOqjIq4uAU8LTD4uoa1w1KpZyyzFtLTEMZpkkOkLfL9eN+KGYdk1Qtwg==
-
 webpack-merge@^5.7.3:
   version "5.8.0"
   resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-5.8.0.tgz#2b39dbf22af87776ad744c390223731d30a68f61"


### PR DESCRIPTION
Apparently the `worker-loader` module in webpack specifically tries to create a Worker with undefined url and catch the error, falling back to the data syntax: https://github.com/webpack-contrib/worker-loader/blob/master/src/runtime/inline.js#L30-L43

This change adds the same contract (to throw on undefined url) to the Worker polyfill we use in zaplib.

## Test Plan
 - Added a test that was failing before the fix