### PR TITLE
Add Github Action to build and push to Docker

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,3 +64,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: zaplib/scripts/ci/tests.sh
+  build_and_push_to_docker_hub:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          username: janpaul123
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - run: zaplib/scripts/docker_ci_build.sh && zaplib/scripts/docker_ci_push.sh

--- a/zaplib/scripts/docker_ci_build.sh
+++ b/zaplib/scripts/docker_ci_build.sh
@@ -5,13 +5,18 @@ set -euo pipefail
 # Per https://stackoverflow.com/a/16349776
 cd "${0%/*}"
 
-TAG=$(git rev-parse HEAD | head -c 8)
-
-# Copy files that need to be transfered to the final image
+# Copy files that need to be transfered to the final image.
 cp ../../rust-toolchain.toml .
 
-docker build -f Dockerfile-ci -t zaplib-ci:$TAG .
+# Warm the cache. Comment out this line and remove the local cache to build fresh.
+docker pull janpaul123/zaplib-ci:latest
 
-# Cleanup
+# Actually build, and tag with current commit hash.
+TAG=$(git rev-parse HEAD | head -c 8)
+docker build -f Dockerfile-ci --cache-from=janpaul123/zaplib-ci:latest -t zaplib-ci:$TAG .
+
+# TODO(JP): In the future we might want to bust the cache periodically.
+# See https://github.com/Zaplib/zaplib/issues/62
+
+# Cleanup.
 rm ./rust-toolchain.toml
-

--- a/zaplib/scripts/docker_ci_push.sh
+++ b/zaplib/scripts/docker_ci_push.sh
@@ -6,6 +6,5 @@ set -euo pipefail
 cd "${0%/*}"
 
 TAG=$(git rev-parse HEAD | head -c 8)
-
 docker tag zaplib-ci:$TAG janpaul123/zaplib-ci:latest
 docker push janpaul123/zaplib-ci:latest


### PR DESCRIPTION
Using the previous image as the cache here was key, this makes the build
really fast.

For now, we don’t ever bust the cache. If that is important, we should
on occasion do a manual build. We can worry more about this later, for
now I just want to have at least something happen when we change the
Dockerfile. I added a TODO about this.