### PR TITLE
Use `globalThis` instead of `self`

### DIFF
--- a/zaplib/web/common.ts
+++ b/zaplib/web/common.ts
@@ -530,7 +530,7 @@ export const getWasmEnv = ({
     },
     randomU64: () =>
       new BigUint64Array(
-        self.crypto.getRandomValues(new Uint32Array(2)).buffer
+        globalThis.crypto.getRandomValues(new Uint32Array(2)).buffer
       )[0],
     sendTaskWorkerMessage: (twMessagePtr) => {
       sendTaskWorkerMessage(taskWorkerSab, parseInt(twMessagePtr));

--- a/zaplib/web/main_worker.ts
+++ b/zaplib/web/main_worker.ts
@@ -40,7 +40,7 @@ const isFirefox =
 // var is_add_to_homescreen_safari = is_mobile_safari && navigator.standalone;
 //var is_oculus_browser = navigator.userAgent.indexOf('OculusBrowser') > -1;
 
-type Timer = { id: number; repeats: number; sysId: number };
+type Timer = { id: number; repeats: number; sysId: NodeJS.Timer };
 
 export type Pointer = {
   x: number;

--- a/zaplib/web/main_worker.ts
+++ b/zaplib/web/main_worker.ts
@@ -33,10 +33,10 @@ import {
   MainWorkerChannelEvent,
 } from "rpc_types";
 
-const rpc = new Rpc<Worker<WasmWorkerRpc>>(self);
+const rpc = new Rpc<Worker<WasmWorkerRpc>>(globalThis);
 
 const isFirefox =
-  self.navigator?.userAgent.toLowerCase().indexOf("firefox") > -1;
+  globalThis.navigator?.userAgent.toLowerCase().indexOf("firefox") > -1;
 // var is_add_to_homescreen_safari = is_mobile_safari && navigator.standalone;
 //var is_oculus_browser = navigator.userAgent.indexOf('OculusBrowser') > -1;
 
@@ -355,8 +355,8 @@ export class WasmApp {
     //         let dy = new_scroll_top - last_scroll_top;
     //         last_scroll_top = new_scroll_top;
     //         last_scroll_left = new_scroll_left;
-    //         self.clearTimeout(scroll_timeout);
-    //         scroll_timeout = self.setTimeout(_ => {
+    //         globalThis.clearTimeout(scroll_timeout);
+    //         scroll_timeout = globalThis.setTimeout(_ => {
     //             ts.scrollTop = 200000;
     //             ts.scrollLeft = 200000;
     //             last_scroll_top = ts.scrollTop;
@@ -567,11 +567,11 @@ export class WasmApp {
     }
     const sysId =
       repeats !== 0
-        ? self.setInterval(() => {
+        ? globalThis.setInterval(() => {
             this.zerdeEventloopEvents.timerFired(id);
             this.doWasmIo();
           }, interval * 1000.0)
-        : self.setTimeout(() => {
+        : globalThis.setTimeout(() => {
             for (let i = 0; i < this.timers.length; i++) {
               const timer = this.timers[i];
               if (timer.id == id) {
@@ -591,9 +591,9 @@ export class WasmApp {
       const timer = this.timers[i];
       if (timer.id == id) {
         if (timer.repeats) {
-          self.clearInterval(timer.sysId);
+          globalThis.clearInterval(timer.sysId);
         } else {
-          self.clearTimeout(timer.sysId);
+          globalThis.clearTimeout(timer.sysId);
         }
         this.timers.splice(i, 1);
         return;
@@ -712,7 +712,7 @@ export class WasmApp {
     if (this.runWebGLPromise) {
       await this.runWebGLPromise;
     }
-    (self.requestAnimationFrame || self.setTimeout)(async () => {
+    (globalThis.requestAnimationFrame || globalThis.setTimeout)(async () => {
       if (this.runWebGLPromise) {
         await this.runWebGLPromise;
       }
@@ -741,7 +741,7 @@ export class WasmApp {
   //   // ok this changes a bunch in how the renderflow works.
   //   // first thing we are going to do is get the vr displays.
   //   // @ts-ignore - Let's not worry about XR.
-  //   const xrSystem = self.navigator.xr;
+  //   const xrSystem = globalThis.navigator.xr;
   //   if (xrSystem) {
   //     xrSystem.isSessionSupported("immersive-vr").then((supported) => {
   //       if (supported) {
@@ -838,91 +838,92 @@ export class WasmApp {
     });
   }
 
-  // Array of function id's wasm can call on us; `self` is pointer to WasmApp.
+  // Array of function id's wasm can call on us; `zelf` is pointer to WasmApp.
+  // (It's not called `self` as to not overload https://developer.mozilla.org/en-US/docs/Web/API/Window/self)
   // Function names are suffixed with the index in the array, and annotated with
   // their name in cx_wasm32.rs, for easier matching.
-  private sendFnTable: ((self: this) => void | boolean)[] = [
+  private sendFnTable: ((zelf: this) => void | boolean)[] = [
     // end
-    function end0(_self) {
+    function end0(_zelf) {
       return true;
     },
     // run_webgl
-    function runWebGL1(self) {
-      const zerdeParserPtr = self.zerdeParser.parseU64();
-      if (self.webglRenderer) {
-        self.webglRenderer.processMessages(Number(zerdeParserPtr));
-        self.exports.deallocWasmMessage(zerdeParserPtr);
+    function runWebGL1(zelf) {
+      const zerdeParserPtr = zelf.zerdeParser.parseU64();
+      if (zelf.webglRenderer) {
+        zelf.webglRenderer.processMessages(Number(zerdeParserPtr));
+        zelf.exports.deallocWasmMessage(zerdeParserPtr);
       } else {
-        self.runWebGLPromise = rpc
+        zelf.runWebGLPromise = rpc
           .send(WorkerEvent.RunWebGL, Number(zerdeParserPtr))
           .then(() => {
-            self.exports.deallocWasmMessage(zerdeParserPtr);
-            self.runWebGLPromise = undefined;
+            zelf.exports.deallocWasmMessage(zerdeParserPtr);
+            zelf.runWebGLPromise = undefined;
           });
       }
     },
     // log
-    function log2(self) {
-      console.log(self.zerdeParser.parseString());
+    function log2(zelf) {
+      console.log(zelf.zerdeParser.parseString());
     },
     // request_animation_frame
-    function requestAnimationFrame3(self) {
-      self.requestAnimationFrame();
+    function requestAnimationFrame3(zelf) {
+      zelf.requestAnimationFrame();
     },
     // set_document_title
-    function setDocumentTitle4(self) {
-      self.setDocumentTitle(self.zerdeParser.parseString());
+    function setDocumentTitle4(zelf) {
+      zelf.setDocumentTitle(zelf.zerdeParser.parseString());
     },
     // set_mouse_cursor
-    function setMouseCursor5(self) {
-      self.setMouseCursor(self.zerdeParser.parseU32());
+    function setMouseCursor5(zelf) {
+      zelf.setMouseCursor(zelf.zerdeParser.parseU32());
     },
     // show_text_ime
-    function showTextIme6(self) {
-      const x = self.zerdeParser.parseF32();
-      const y = self.zerdeParser.parseF32();
+    function showTextIme6(zelf) {
+      const x = zelf.zerdeParser.parseF32();
+      const y = zelf.zerdeParser.parseF32();
       rpc.send(WorkerEvent.ShowTextIME, { x, y });
     },
     // hide_text_ime
-    function hideTextIme7(_self) {
+    function hideTextIme7(_zelf) {
       // TODO(JP): doesn't seem to do anything, is that intentional?
     },
     // text_copy_response
-    function textCopyResponse8(self) {
-      const textCopyResponse = self.zerdeParser.parseString();
+    function textCopyResponse8(zelf) {
+      const textCopyResponse = zelf.zerdeParser.parseString();
       rpc.send(WorkerEvent.TextCopyResponse, textCopyResponse);
     },
     // start_timer
-    function startTimer9(self) {
-      const repeats = self.zerdeParser.parseU32();
-      const id = self.zerdeParser.parseF64();
-      const interval = self.zerdeParser.parseF64();
-      self.startTimer(id, interval, repeats);
+    function startTimer9(zelf) {
+      const repeats = zelf.zerdeParser.parseU32();
+      const id = zelf.zerdeParser.parseF64();
+      const interval = zelf.zerdeParser.parseF64();
+      zelf.startTimer(id, interval, repeats);
     },
     // stop_timer
-    function stopTimer10(self) {
-      const id = self.zerdeParser.parseF64();
-      self.stopTimer(id);
+    function stopTimer10(zelf) {
+      const id = zelf.zerdeParser.parseF64();
+      zelf.stopTimer(id);
     },
     // xr_start_presenting
-    function xrStartPresenting11(self) {
-      self.xrStartPresenting();
+    function xrStartPresenting11(zelf) {
+      zelf.xrStartPresenting();
     },
     // xr_stop_presenting
-    function xrStopPresenting12(self) {
-      self.xrStopPresenting();
+    function xrStopPresenting12(zelf) {
+      zelf.xrStopPresenting();
     },
     // http_send
-    function httpSend13(self) {
-      const port = self.zerdeParser.parseU32();
-      const signalId = self.zerdeParser.parseU32();
-      const verb = self.zerdeParser.parseString();
-      const path = self.zerdeParser.parseString();
-      const proto = self.zerdeParser.parseString();
-      const domain = self.zerdeParser.parseString();
-      const contentType = self.zerdeParser.parseString();
-      const body = self.zerdeParser.parseU8Slice();
-      self.httpSend(
+    function httpSend13(zelf) {
+      const port = zelf.zerdeParser.parseU32();
+      const signalId = zelf.zerdeParser.parseU32();
+      const verb = zelf.zerdeParser.parseString();
+      const path = zelf.zerdeParser.parseString();
+      const proto = zelf.zerdeParser.parseString();
+      const domain = zelf.zerdeParser.parseString();
+      const contentType = zelf.zerdeParser.parseString();
+      const body = zelf.zerdeParser.parseU8Slice();
+      zelf.httpSend(
         verb,
         path,
         proto,
@@ -934,31 +935,31 @@ export class WasmApp {
       );
     },
     // fullscreen
-    function fullscreen14(_self) {
+    function fullscreen14(_zelf) {
       rpc.send(WorkerEvent.Fullscreen);
     },
     // normalscreen
-    function normalscreen15(_self) {
+    function normalscreen15(_zelf) {
       rpc.send(WorkerEvent.Normalscreen);
     },
     // websocket_send
-    function websocketSend16(self) {
-      const url = self.zerdeParser.parseString();
-      const data = self.zerdeParser.parseU8Slice();
-      self.websocketSend(url, data);
+    function websocketSend16(zelf) {
+      const url = zelf.zerdeParser.parseString();
+      const data = zelf.zerdeParser.parseU8Slice();
+      zelf.websocketSend(url, data);
     },
     // enable_global_file_drop_target
-    function enableGlobalFileDropTarget17(self) {
-      self.enableGlobalFileDropTarget();
+    function enableGlobalFileDropTarget17(zelf) {
+      zelf.enableGlobalFileDropTarget();
     },
     // call_js
-    function callJs18(self) {
-      const fnName = self.zerdeParser.parseString();
-      const params = self.zerdeParser.parseZapParams();
+    function callJs18(zelf) {
+      const fnName = zelf.zerdeParser.parseString();
+      const params = zelf.zerdeParser.parseZapParams();
       if (fnName === "_zaplibReturnParams") {
         const callbackId = JSON.parse(params[0] as string);
-        self.callRustAsyncPendingCallbacks[callbackId](params.slice(1));
-        delete self.callRustAsyncPendingCallbacks[callbackId];
+        zelf.callRustAsyncPendingCallbacks[callbackId](params.slice(1));
+        delete zelf.callRustAsyncPendingCallbacks[callbackId];
       } else {
         rpc.send(WorkerEvent.CallJs, { fnName, params });
       }

--- a/zaplib/web/wasm_runtime.ts
+++ b/zaplib/web/wasm_runtime.ts
@@ -356,8 +356,8 @@ function initializeCanvas(canvas: HTMLCanvasElement): CanvasData {
     if (wasmInitialized()) rpc.send(WorkerEvent.WindowBlur);
   });
 
-  const isMobileSafari = self.navigator.platform.match(/iPhone|iPad/i);
-  const isAndroid = self.navigator.userAgent.match(/Android/i);
+  const isMobileSafari = globalThis.navigator.platform.match(/iPhone|iPad/i);
+  const isAndroid = globalThis.navigator.userAgent.match(/Android/i);
 
   if (!isMobileSafari && !isAndroid) {
     // mobile keyboards are unusable on a UI like this
@@ -418,7 +418,7 @@ function initializeCanvas(canvas: HTMLCanvasElement): CanvasData {
     mq.addEventListener("change", () => onScreenResize());
   } else {
     // poll for it. yes. its terrible
-    self.setInterval(() => {
+    globalThis.setInterval(() => {
       if (window.devicePixelRatio != dpiFactor) {
         dpiFactor = window.devicePixelRatio;
         onScreenResize();
@@ -771,7 +771,7 @@ export const initialize: Initialize = (initParams) => {
 
         WebAssembly.instantiate(wasmModule, { env }).then((instance: any) => {
           const offscreenCanvas =
-            self.OffscreenCanvas &&
+            globalThis.OffscreenCanvas &&
             canvasData.renderingMethod instanceof OffscreenCanvas
               ? canvasData.renderingMethod
               : undefined;

--- a/zaplib/web/webgl_renderer.ts
+++ b/zaplib/web/webgl_renderer.ts
@@ -645,31 +645,31 @@ export class WebGLRenderer {
 
   private uniformFnTable: Record<
     string,
-    (self: WebGLRenderer, loc: WebGLUniformLocation | null, off: number) => void
+    (zelf: WebGLRenderer, loc: WebGLUniformLocation | null, off: number) => void
   > = {
-    float: function setFloat(self, loc, off) {
+    float: function setFloat(zelf, loc, off) {
       const slot = off >> 2;
-      self.gl.uniform1f(loc, self.basef32[slot]);
+      zelf.gl.uniform1f(loc, zelf.basef32[slot]);
     },
-    vec2: function setVec2(self, loc, off) {
+    vec2: function setVec2(zelf, loc, off) {
       const slot = off >> 2;
-      const basef32 = self.basef32;
-      self.gl.uniform2f(loc, basef32[slot], basef32[slot + 1]);
+      const basef32 = zelf.basef32;
+      zelf.gl.uniform2f(loc, basef32[slot], basef32[slot + 1]);
     },
-    vec3: function setVec3(self, loc, off) {
+    vec3: function setVec3(zelf, loc, off) {
       const slot = off >> 2;
-      const basef32 = self.basef32;
-      self.gl.uniform3f(
+      const basef32 = zelf.basef32;
+      zelf.gl.uniform3f(
         loc,
         basef32[slot],
         basef32[slot + 1],
         basef32[slot + 2]
       );
     },
-    vec4: function setVec4(self, loc, off) {
+    vec4: function setVec4(zelf, loc, off) {
       const slot = off >> 2;
-      const basef32 = self.basef32;
-      self.gl.uniform4f(
+      const basef32 = zelf.basef32;
+      zelf.gl.uniform4f(
         loc,
         basef32[slot],
         basef32[slot + 1],
@@ -677,97 +677,98 @@ export class WebGLRenderer {
         basef32[slot + 3]
       );
     },
-    mat2: function setMat2(self, loc, off) {
-      self.gl.uniformMatrix2fv(
+    mat2: function setMat2(zelf, loc, off) {
+      zelf.gl.uniformMatrix2fv(
         loc,
         false,
-        new Float32Array(self.memory.buffer, off, 4)
+        new Float32Array(zelf.memory.buffer, off, 4)
       );
     },
-    mat3: function setMat3(self, loc, off) {
-      self.gl.uniformMatrix3fv(
+    mat3: function setMat3(zelf, loc, off) {
+      zelf.gl.uniformMatrix3fv(
         loc,
         false,
-        new Float32Array(self.memory.buffer, off, 9)
+        new Float32Array(zelf.memory.buffer, off, 9)
       );
     },
-    mat4: function setMat4(self, loc, off) {
-      const mat4 = new Float32Array(self.memory.buffer, off, 16);
-      self.gl.uniformMatrix4fv(loc, false, mat4);
+    mat4: function setMat4(zelf, loc, off) {
+      const mat4 = new Float32Array(zelf.memory.buffer, off, 16);
+      zelf.gl.uniformMatrix4fv(loc, false, mat4);
     },
   };
 
-  // Array of function id's wasm can call on us; `self` is pointer to WebGLRenderer.
+  // Array of function id's wasm can call on us; `zelf` is pointer to WebGLRenderer.
+  // (It's not called `self` as to not overload https://developer.mozilla.org/en-US/docs/Web/API/Window/self)
   // Function names are suffixed with the index in the array, and annotated with
   // their name in cx_webgl.rs, for easier matching.
-  private sendFnTable: ((self: this) => void | boolean)[] = [
+  private sendFnTable: ((zelf: this) => void | boolean)[] = [
     // end
-    function end0(_self) {
+    function end0(_zelf) {
       return true;
     },
     // compile_webgl_shader
-    function compileWebGLShader1(self) {
+    function compileWebGLShader1(zelf) {
       function parseShvarvec(): Uniform[] {
-        const len = self.zerdeParser.parseU32();
+        const len = zelf.zerdeParser.parseU32();
         const vars: Uniform[] = [];
         for (let i = 0; i < len; i++) {
           vars.push({
-            ty: self.zerdeParser.parseString() as UniformType,
-            name: self.zerdeParser.parseString(),
+            ty: zelf.zerdeParser.parseString() as UniformType,
+            name: zelf.zerdeParser.parseString(),
           });
         }
         return vars;
       }
 
       const ash = {
-        shaderId: self.zerdeParser.parseU32(),
-        fragment: self.zerdeParser.parseString(),
-        vertex: self.zerdeParser.parseString(),
-        geometrySlots: self.zerdeParser.parseU32(),
-        instanceSlots: self.zerdeParser.parseU32(),
+        shaderId: zelf.zerdeParser.parseU32(),
+        fragment: zelf.zerdeParser.parseString(),
+        vertex: zelf.zerdeParser.parseString(),
+        geometrySlots: zelf.zerdeParser.parseU32(),
+        instanceSlots: zelf.zerdeParser.parseU32(),
         passUniforms: parseShvarvec(),
         viewUniforms: parseShvarvec(),
         drawUniforms: parseShvarvec(),
         userUniforms: parseShvarvec(),
         textureSlots: parseShvarvec(),
       };
-      self.compileWebGLShader(ash);
+      zelf.compileWebGLShader(ash);
     },
     // alloc_array_buffer
-    function allocArrayBuffer2(self) {
-      const arrayBufferId = self.zerdeParser.parseU32();
-      const len = self.zerdeParser.parseU32();
-      const pointer = self.zerdeParser.parseU32();
-      const array = new Float32Array(self.memory.buffer, pointer, len);
-      self.allocArrayBuffer(arrayBufferId, array);
+    function allocArrayBuffer2(zelf) {
+      const arrayBufferId = zelf.zerdeParser.parseU32();
+      const len = zelf.zerdeParser.parseU32();
+      const pointer = zelf.zerdeParser.parseU32();
+      const array = new Float32Array(zelf.memory.buffer, pointer, len);
+      zelf.allocArrayBuffer(arrayBufferId, array);
     },
     // alloc_index_buffer
-    function allocIndexBuffer3(self) {
-      const indexBufferId = self.zerdeParser.parseU32();
-      const len = self.zerdeParser.parseU32();
-      const pointer = self.zerdeParser.parseU32();
-      const array = new Uint32Array(self.memory.buffer, pointer, len);
-      self.allocIndexBuffer(indexBufferId, array);
+    function allocIndexBuffer3(zelf) {
+      const indexBufferId = zelf.zerdeParser.parseU32();
+      const len = zelf.zerdeParser.parseU32();
+      const pointer = zelf.zerdeParser.parseU32();
+      const array = new Uint32Array(zelf.memory.buffer, pointer, len);
+      zelf.allocIndexBuffer(indexBufferId, array);
     },
     // alloc_vao
-    function allocVao4(self) {
-      const vaoId = self.zerdeParser.parseU32();
-      const shaderId = self.zerdeParser.parseU32();
-      const geomIbId = self.zerdeParser.parseU32();
-      const geomVbId = self.zerdeParser.parseU32();
-      const instVbId = self.zerdeParser.parseU32();
-      self.allocVao(vaoId, shaderId, geomIbId, geomVbId, instVbId);
+    function allocVao4(zelf) {
+      const vaoId = zelf.zerdeParser.parseU32();
+      const shaderId = zelf.zerdeParser.parseU32();
+      const geomIbId = zelf.zerdeParser.parseU32();
+      const geomVbId = zelf.zerdeParser.parseU32();
+      const instVbId = zelf.zerdeParser.parseU32();
+      zelf.allocVao(vaoId, shaderId, geomIbId, geomVbId, instVbId);
     },
     // draw_call
-    function drawCall5(self) {
-      const shaderId = self.zerdeParser.parseU32();
-      const vaoId = self.zerdeParser.parseU32();
-      const uniformsPassPtr = self.zerdeParser.parseU32();
-      const uniformsViewPtr = self.zerdeParser.parseU32();
-      const uniformsDrawPtr = self.zerdeParser.parseU32();
-      const uniformsUserPtr = self.zerdeParser.parseU32();
-      const textures = self.zerdeParser.parseU32();
-      self.drawCall(
+    function drawCall5(zelf) {
+      const shaderId = zelf.zerdeParser.parseU32();
+      const vaoId = zelf.zerdeParser.parseU32();
+      const uniformsPassPtr = zelf.zerdeParser.parseU32();
+      const uniformsViewPtr = zelf.zerdeParser.parseU32();
+      const uniformsDrawPtr = zelf.zerdeParser.parseU32();
+      const uniformsUserPtr = zelf.zerdeParser.parseU32();
+      const textures = zelf.zerdeParser.parseU32();
+      zelf.drawCall(
         shaderId,
         vaoId,
         uniformsPassPtr,
@@ -778,53 +779,53 @@ export class WebGLRenderer {
       );
     },
     // update_texture_image2d
-    function allocTexture6(self) {
-      const textureId = self.zerdeParser.parseU32();
-      const width = self.zerdeParser.parseU32();
-      const height = self.zerdeParser.parseU32();
-      const dataPtr = self.zerdeParser.parseU32();
-      self.allocTexture(textureId, width, height, dataPtr);
+    function allocTexture6(zelf) {
+      const textureId = zelf.zerdeParser.parseU32();
+      const width = zelf.zerdeParser.parseU32();
+      const height = zelf.zerdeParser.parseU32();
+      const dataPtr = zelf.zerdeParser.parseU32();
+      zelf.allocTexture(textureId, width, height, dataPtr);
     },
     // begin_render_targets
-    function beginRenderTargets7(self) {
-      const passId = self.zerdeParser.parseU32();
-      const width = self.zerdeParser.parseU32();
-      const height = self.zerdeParser.parseU32();
-      self.beginRenderTargets(passId, width, height);
+    function beginRenderTargets7(zelf) {
+      const passId = zelf.zerdeParser.parseU32();
+      const width = zelf.zerdeParser.parseU32();
+      const height = zelf.zerdeParser.parseU32();
+      zelf.beginRenderTargets(passId, width, height);
     },
     // add_color_target
-    function addColorTarget8(self) {
-      const textureId = self.zerdeParser.parseU32();
-      const initOnly = self.zerdeParser.parseU32();
-      const r = self.zerdeParser.parseF32();
-      const g = self.zerdeParser.parseF32();
-      const b = self.zerdeParser.parseF32();
-      const a = self.zerdeParser.parseF32();
-      self.addColorTarget(textureId, initOnly, r, g, b, a);
+    function addColorTarget8(zelf) {
+      const textureId = zelf.zerdeParser.parseU32();
+      const initOnly = zelf.zerdeParser.parseU32();
+      const r = zelf.zerdeParser.parseF32();
+      const g = zelf.zerdeParser.parseF32();
+      const b = zelf.zerdeParser.parseF32();
+      const a = zelf.zerdeParser.parseF32();
+      zelf.addColorTarget(textureId, initOnly, r, g, b, a);
     },
     // set_depth_target
-    function setDepthTarget9(self) {
-      const textureId = self.zerdeParser.parseU32();
-      const initOnly = self.zerdeParser.parseU32();
-      const depth = self.zerdeParser.parseF32();
-      self.setDepthTarget(textureId, initOnly, depth);
+    function setDepthTarget9(zelf) {
+      const textureId = zelf.zerdeParser.parseU32();
+      const initOnly = zelf.zerdeParser.parseU32();
+      const depth = zelf.zerdeParser.parseF32();
+      zelf.setDepthTarget(textureId, initOnly, depth);
     },
     // end_render_targets
-    function endRenderTargets10(self) {
-      self.endRenderTargets();
+    function endRenderTargets10(zelf) {
+      zelf.endRenderTargets();
     },
     // set_default_depth_and_blend_mode
-    function setDefaultDepthAndBlendMode11(self) {
-      self.setDefaultDepthAndBlendMode();
+    function setDefaultDepthAndBlendMode11(zelf) {
+      zelf.setDefaultDepthAndBlendMode();
     },
     // begin_main_canvas
-    function beginMainCanvas12(self) {
-      const r = self.zerdeParser.parseF32();
-      const g = self.zerdeParser.parseF32();
-      const b = self.zerdeParser.parseF32();
-      const a = self.zerdeParser.parseF32();
-      const depth = self.zerdeParser.parseF32();
-      self.beginMainCanvas(r, g, b, a, depth);
+    function beginMainCanvas12(zelf) {
+      const r = zelf.zerdeParser.parseF32();
+      const g = zelf.zerdeParser.parseF32();
+      const b = zelf.zerdeParser.parseF32();
+      const a = zelf.zerdeParser.parseF32();
+      const depth = zelf.zerdeParser.parseF32();
+      zelf.beginMainCanvas(r, g, b, a, depth);
     },
   ];
 }

--- a/zaplib/web/zap_buffer.ts
+++ b/zaplib/web/zap_buffer.ts
@@ -185,21 +185,21 @@ export function overwriteTypedArraysWithZapArrays(): void {
   if (overwriteTypedArraysWithZapArraysCalled) return;
 
   for (const [cls, zapCls] of Object.entries(classesToExtend)) {
-    if (cls in self) {
+    if (cls in globalThis) {
       // @ts-ignore
-      self[cls] = self[zapCls];
+      globalThis[cls] = globalThis[zapCls];
     }
   }
-  patchPostMessage(self);
+  patchPostMessage(globalThis);
 
   // In Safari nested workers are not defined.
-  if (self.Worker) {
-    patchPostMessage(self.Worker);
+  if (globalThis.Worker) {
+    patchPostMessage(globalThis.Worker);
   }
 
   // Skipping this in nodejs case as web-worker polyfill doesn't provide MessagePort
-  if (self.MessagePort) {
-    patchPostMessage(self.MessagePort);
+  if (globalThis.MessagePort) {
+    patchPostMessage(globalThis.MessagePort);
   }
   overwriteTypedArraysWithZapArraysCalled = true;
 }

--- a/zaplib/web/zaplib_nodejs_polyfill.ts
+++ b/zaplib/web/zaplib_nodejs_polyfill.ts
@@ -4,8 +4,8 @@
 // Worker poylfil to use Webworkers
 // @ts-ignore
 import Worker from "vendor/web-worker/node";
-self.Worker = Worker;
+globalThis.Worker = Worker;
 
 // eslint-disable-next-line
 const threads = require("worker_threads");
-self.MessageChannel = threads.MessageChannel;
+globalThis.MessageChannel = threads.MessageChannel;

--- a/zaplib/web/zaplib_worker_runtime.ts
+++ b/zaplib/web/zaplib_worker_runtime.ts
@@ -3,7 +3,7 @@
 // The "Zaplib WebWorker runtime" exposes some common Zaplib functions inside your WebWorkers, like `callRustAsync`.
 //
 // Include the output of this (zaplib_worker_runtime) at the start of each worker, and initialize the runtime
-// by calling `self.initializeWorker` with a `MessagePort` obtained by `newWorkerPort` (which is
+// by calling `globalThis.initializeWorker` with a `MessagePort` obtained by `newWorkerPort` (which is
 // available on `window` in the main browser thread, and in any worker that already has the runtime running). You
 // can pass the port to the worker using `postMessage`; just be sure to include it in the list of transferables.
 //


### PR DESCRIPTION
`self` works in the browser main thread and in workers. But it does not
work in NodeJS. :( [`globalThis`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis) was introduced as a variable that is
truly supported in all environments to represent the global context.

This makes our code more compatible with NodeJS.

I also renamed unrelated uses of `self` to `zelf` as to not overload the
aforementioned `self`. I added a comment in the places where we do this.