### PR TITLE
Wait until after tests before downloading previous screenshots + less flakey screenshots

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,15 @@ jobs:
         with:
           fetch-depth: 0 # Get full repo; necessary for `find_screenshots_compare_commit.sh`
       - uses: Swatinem/rust-cache@v1
+      - uses: actions/setup-node@master
+        with:
+          node-version: '16.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: zaplib/scripts/ci/browser_tests.sh
+        env:
+          BROWSERSTACK_KEY: ${{ secrets.BROWSERSTACK_KEY }}
+      # Download the previous screenshots after running the tests, to give the main branch a bit
+      # more time to upload, if it was just merged.
       - run: zaplib/scripts/ci/find_screenshots_compare_commit.sh
       - uses: dawidd6/action-download-artifact@v2
         with:
@@ -32,13 +41,8 @@ jobs:
           name: screenshots
           path: previous_screenshots/
         continue-on-error: true
-      - uses: actions/setup-node@master
-        with:
-          node-version: '16.x'
-          registry-url: 'https://registry.npmjs.org'
-      - run: zaplib/scripts/ci/browser_tests.sh
+      - run: zaplib/scripts/ci/browser_tests_upload_screenshots.sh
         env:
-          BROWSERSTACK_KEY: ${{ secrets.BROWSERSTACK_KEY }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: us-east-1

--- a/zaplib/ci/src/cmd.rs
+++ b/zaplib/ci/src/cmd.rs
@@ -301,7 +301,7 @@ async fn examples_screenshots(browser_name: &str, driver: &mut WebDriver, local_
                     clearInterval(interval);
                     setTimeout(() => {
                         done("SUCCESS");
-                    }, 2000); // TODO(JP): Shorten this time. See https://github.com/Zaplib/zaplib/issues/29
+                    }, 3000); // TODO(JP): Shorten this time. See https://github.com/Zaplib/zaplib/issues/29
                 }
             }, 10);
         "#;

--- a/zaplib/scripts/ci/browser_tests.sh
+++ b/zaplib/scripts/ci/browser_tests.sh
@@ -43,29 +43,3 @@ popd
 export BROWSERSTACK_LOCAL_IDENTIFIER=$(echo $RANDOM$RANDOM$RANDOM)
 BrowserStackLocal --key $BROWSERSTACK_KEY --debug-utility --daemon start --local-identifier $BROWSERSTACK_LOCAL_IDENTIFIER
 cargo run -p zaplib_ci -- --webdriver-url "https://jpposma_0ZuiXP:${BROWSERSTACK_KEY}@hub-cloud.browserstack.com/wd/hub" --browserstack-local-identifier $BROWSERSTACK_LOCAL_IDENTIFIER
-
-# Screenshots are saved in `screenshots/`. Previous ones in `previous_screenshots/`. Let's compare!
-# `--ignoreChange` makes it so this call doesn't fail when there are changed screenshots; we don't
-# want to block merging in that case.
-zaplib/web/node_modules/.bin/reg-cli screenshots/ previous_screenshots/ diff_screenshots/ --report ./index.html --json ./reg.json --ignoreChange --enableAntialias --matchingThreshold 0.05
-# Now let's bundle everything up in screenshots_report/
-mkdir screenshots_report/
-mv index.html screenshots_report/
-mv reg.json screenshots_report/
-mv screenshots/ screenshots_report/
-mv previous_screenshots/ screenshots_report/
-mv diff_screenshots/ screenshots_report/
-aws s3 cp --recursive screenshots_report/ s3://zaplib-screenshots/$GITHUB_SHA
-
-if grep --fixed-strings '"newItems":[]' screenshots_report/reg.json && grep --fixed-strings '"deletedItems":[]' screenshots_report/reg.json && grep --fixed-strings '"failedItems":[]' screenshots_report/reg.json
-then
-  echo "SCREENSHOT_GITHUB_MESSAGE=[✅ No screenshot diffs found.](http://zaplib-screenshots.s3-website-us-east-1.amazonaws.com/$GITHUB_SHA)" >> $GITHUB_ENV
-else
-  if grep --fixed-strings '"deletedItems":[]' screenshots_report/reg.json && grep --fixed-strings '"failedItems":[]' screenshots_report/reg.json && grep --fixed-strings '"passedItems":[]' screenshots_report/reg.json
-  then
-    echo "SCREENSHOT_GITHUB_MESSAGE=[⚠️ Only new screenshots found.](http://zaplib-screenshots.s3-website-us-east-1.amazonaws.com/$GITHUB_SHA) This typically happens when the base commit screenshots were not built yet; just rerun the workspace. If that doesn't help, please contact a maintainer for help." >> $GITHUB_ENV
-  else
-    echo "SCREENSHOT_GITHUB_MESSAGE=[🤔 Screenshot diffs found.](http://zaplib-screenshots.s3-website-us-east-1.amazonaws.com/$GITHUB_SHA) Please look at the screenshots and tag this comment with 👍 or 👎. Only merge when both the PR author and a reviewer are happy with the changes." >> $GITHUB_ENV
-  fi
-fi
-

--- a/zaplib/scripts/ci/browser_tests_upload_screenshots.sh
+++ b/zaplib/scripts/ci/browser_tests_upload_screenshots.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+# Per https://stackoverflow.com/a/16349776; go to repo root
+cd "${0%/*}/../../.."
+
+# Screenshots are saved in `screenshots/`. Previous ones in `previous_screenshots/`. Let's compare!
+# `--ignoreChange` makes it so this call doesn't fail when there are changed screenshots; we don't
+# want to block merging in that case.
+zaplib/web/node_modules/.bin/reg-cli screenshots/ previous_screenshots/ diff_screenshots/ --report ./index.html --json ./reg.json --ignoreChange --enableAntialias --matchingThreshold 0.05
+# Now let's bundle everything up in screenshots_report/
+mkdir screenshots_report/
+mv index.html screenshots_report/
+mv reg.json screenshots_report/
+mv screenshots/ screenshots_report/
+mv previous_screenshots/ screenshots_report/
+mv diff_screenshots/ screenshots_report/
+aws s3 cp --recursive screenshots_report/ s3://zaplib-screenshots/$GITHUB_SHA
+
+if grep --fixed-strings '"newItems":[]' screenshots_report/reg.json && grep --fixed-strings '"deletedItems":[]' screenshots_report/reg.json && grep --fixed-strings '"failedItems":[]' screenshots_report/reg.json
+then
+  echo "SCREENSHOT_GITHUB_MESSAGE=[✅ No screenshot diffs found.](http://zaplib-screenshots.s3-website-us-east-1.amazonaws.com/$GITHUB_SHA)" >> $GITHUB_ENV
+else
+  if grep --fixed-strings '"deletedItems":[]' screenshots_report/reg.json && grep --fixed-strings '"failedItems":[]' screenshots_report/reg.json && grep --fixed-strings '"passedItems":[]' screenshots_report/reg.json
+  then
+    echo "SCREENSHOT_GITHUB_MESSAGE=[⚠️ Only new screenshots found.](http://zaplib-screenshots.s3-website-us-east-1.amazonaws.com/$GITHUB_SHA) This typically happens when the base commit screenshots were not built yet; just rerun the workspace. If that doesn't help, please contact a maintainer for help." >> $GITHUB_ENV
+  else
+    echo "SCREENSHOT_GITHUB_MESSAGE=[🤔 Screenshot diffs found.](http://zaplib-screenshots.s3-website-us-east-1.amazonaws.com/$GITHUB_SHA) Please look at the screenshots and tag this comment with 👍 or 👎. Only merge when both the PR author and a reviewer are happy with the changes." >> $GITHUB_ENV
+  fi
+fi
+

--- a/zaplib/scripts/ci/browser_tests_upload_screenshots.sh
+++ b/zaplib/scripts/ci/browser_tests_upload_screenshots.sh
@@ -8,7 +8,7 @@ cd "${0%/*}/../../.."
 # Screenshots are saved in `screenshots/`. Previous ones in `previous_screenshots/`. Let's compare!
 # `--ignoreChange` makes it so this call doesn't fail when there are changed screenshots; we don't
 # want to block merging in that case.
-zaplib/web/node_modules/.bin/reg-cli screenshots/ previous_screenshots/ diff_screenshots/ --report ./index.html --json ./reg.json --ignoreChange --enableAntialias --matchingThreshold 0.05
+zaplib/web/node_modules/.bin/reg-cli screenshots/ previous_screenshots/ diff_screenshots/ --report ./index.html --json ./reg.json --ignoreChange --enableAntialias --matchingThreshold 0.15
 # Now let's bundle everything up in screenshots_report/
 mkdir screenshots_report/
 mv index.html screenshots_report/


### PR DESCRIPTION
To give the main branch a bit more time to upload, if it was just
merged.

I also added a second commit that should hopefully make the screenshots a bit more stable.