### PR TITLE
Add “thresholdPixel” to ignore up to 10 different pixels

### DIFF
--- a/zaplib/scripts/ci/browser_tests_upload_screenshots.sh
+++ b/zaplib/scripts/ci/browser_tests_upload_screenshots.sh
@@ -8,7 +8,10 @@ cd "${0%/*}/../../.."
 # Screenshots are saved in `screenshots/`. Previous ones in `previous_screenshots/`. Let's compare!
 # `--ignoreChange` makes it so this call doesn't fail when there are changed screenshots; we don't
 # want to block merging in that case.
-zaplib/web/node_modules/.bin/reg-cli screenshots/ previous_screenshots/ diff_screenshots/ --report ./index.html --json ./reg.json --ignoreChange --enableAntialias --matchingThreshold 0.15
+# We use `--matchingThreshold` and `--thresholdPixel` because the GPU-rendered images come out slightly
+# different now and then. We suspect that this is because of differences in GPU hardware between
+# Browserstack runs.
+zaplib/web/node_modules/.bin/reg-cli screenshots/ previous_screenshots/ diff_screenshots/ --report ./index.html --json ./reg.json --ignoreChange --enableAntialias --matchingThreshold 0.15 --thresholdPixel 10
 # Now let's bundle everything up in screenshots_report/
 mkdir screenshots_report/
 mv index.html screenshots_report/


### PR DESCRIPTION
To prevent false positives because of differences in GPU hardware.