### PR TITLE
Better typing for call rust functions

### DIFF
--- a/zaplib/web/common.ts
+++ b/zaplib/web/common.ts
@@ -543,7 +543,7 @@ export function transformParamsFromRustImpl(
   destructor: (arcPtr: number) => void,
   mutableDestructor: (bufferData: MutableBufferData) => void,
   params: RustZapParam[]
-): (string | ZapArray)[] {
+): ZapParam[] {
   return params.map((param) => {
     if (typeof param === "string") {
       return param;

--- a/zaplib/web/test_suite/test_suite.ts
+++ b/zaplib/web/test_suite/test_suite.ts
@@ -177,12 +177,10 @@ zaplib
         const buffer = await zaplib.createReadOnlyBuffer(
           new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8])
         );
-        const result = (
-          await zaplib.callRustAsync("array_multiply_u8_readonly", [
-            JSON.stringify(10),
-            buffer,
-          ])
-        )[0] as Uint8Array;
+        const [result] = await zaplib.callRustAsync<[Uint8Array]>(
+          "array_multiply_u8_readonly",
+          [JSON.stringify(10), buffer]
+        );
         expect(result.length, 8);
         expect(result[0], 10);
         expect(result[1], 20);
@@ -228,12 +226,10 @@ zaplib
         mutableBuffer[2] = 0;
         mutableBuffer[3] = 0;
 
-        const result = (
-          await zaplib.callRustAsync("array_multiply_u8", [
-            JSON.stringify(10),
-            mutableBuffer,
-          ])
-        )[0] as Uint8Array;
+        const [result] = await zaplib.callRustAsync<[Uint8Array]>(
+          "array_multiply_u8",
+          [JSON.stringify(10), mutableBuffer]
+        );
         expect(result.length, 8);
         expect(result[0], 0);
         expect(result[1], 0);
@@ -252,12 +248,10 @@ zaplib
       "Call Rust with Float32Array": async () => {
         // Using a normal array
         const input = new Float32Array([0.1, 0.9, 0.3]);
-        const result = (
-          await zaplib.callRustAsync("array_multiply_f32", [
-            JSON.stringify(10),
-            input,
-          ])
-        )[0] as Float32Array;
+        const [result] = await zaplib.callRustAsync<[Float32Array]>(
+          "array_multiply_f32",
+          [JSON.stringify(10), input]
+        );
         expect(result.length, 3);
         expect(result[0], 1);
         expect(result[1], 9);
@@ -267,12 +261,10 @@ zaplib
         const input2 = await zaplib.createMutableBuffer(
           new Float32Array([0.1, 0.9, 0.3])
         );
-        const result2 = (
-          await zaplib.callRustAsync("array_multiply_f32", [
-            JSON.stringify(10),
-            input2,
-          ])
-        )[0] as Float32Array;
+        const [result2] = await zaplib.callRustAsync<[Float32Array]>(
+          "array_multiply_f32",
+          [JSON.stringify(10), input2]
+        );
 
         expect(result2.length, 3);
         expect(result2[0], 1);
@@ -284,12 +276,10 @@ zaplib
           new Float32Array([0.1, 0.9, 0.3])
         );
 
-        const result3 = (
-          await zaplib.callRustAsync("array_multiply_f32_readonly", [
-            JSON.stringify(10),
-            input3,
-          ])
-        )[0] as Float32Array;
+        const [result3] = await zaplib.callRustAsync<[Float32Array]>(
+          "array_multiply_f32_readonly",
+          [JSON.stringify(10), input3]
+        );
 
         expect(result3.length, 3);
         expect(result3[0], 1);
@@ -321,10 +311,10 @@ zaplib
       "Call Rust with Float32Array (in same thread)": async () => {
         // Using a normal array
         const input = new Float32Array([0.1, 0.9, 0.3]);
-        const result = zaplib.callRustSync("array_multiply_f32", [
+        const [result] = zaplib.callRustSync("array_multiply_f32", [
           JSON.stringify(10),
           input,
-        ])[0] as Float32Array;
+        ]);
         expect(result.length, 3);
         expect(result[0], 1);
         expect(result[1], 9);
@@ -334,10 +324,10 @@ zaplib
         const input2 = await zaplib.createMutableBuffer(
           new Float32Array([0.1, 0.9, 0.3])
         );
-        const result2 = zaplib.callRustSync("array_multiply_f32", [
+        const [result2] = zaplib.callRustSync("array_multiply_f32", [
           JSON.stringify(10),
           input2,
-        ])[0] as Float32Array;
+        ]);
         expect(result2.length, 3);
         expect(result2[0], 1);
         expect(result2[1], 9);
@@ -348,10 +338,10 @@ zaplib
           new Float32Array([0.1, 0.9, 0.3])
         );
 
-        const result3 = zaplib.callRustSync("array_multiply_f32_readonly", [
+        const [result3] = zaplib.callRustSync("array_multiply_f32_readonly", [
           JSON.stringify(10),
           input3,
-        ])[0] as Float32Array;
+        ]);
         expect(result3.length, 3);
         expect(result3[0], 1);
         expect(result3[1], 9);

--- a/zaplib/web/test_suite/test_suite_worker.ts
+++ b/zaplib/web/test_suite/test_suite_worker.ts
@@ -41,12 +41,10 @@ const tests = {
   testCallRustAsyncFloat32ArrayFromWorker: async () => {
     // Using a normal array
     const input = new Float32Array([0.1, 0.9, 0.3]);
-    const result = (
-      await zaplib.callRustAsync("array_multiply_f32", [
-        JSON.stringify(10),
-        input,
-      ])
-    )[0] as Float32Array;
+    const [result] = await zaplib.callRustAsync("array_multiply_f32", [
+      JSON.stringify(10),
+      input,
+    ]);
     expect(result.length, 3);
     expect(result[0], 1);
     expect(result[1], 9);
@@ -56,12 +54,10 @@ const tests = {
     const input2 = zaplib.createMutableBuffer(
       new Float32Array([0.1, 0.9, 0.3])
     );
-    const result2 = (
-      await zaplib.callRustAsync("array_multiply_f32", [
-        JSON.stringify(10),
-        input2,
-      ])
-    )[0] as Float32Array;
+    const [result2] = await zaplib.callRustAsync("array_multiply_f32", [
+      JSON.stringify(10),
+      input2,
+    ]);
     expect(result2.length, 3);
     expect(result2[0], 1);
     expect(result2[1], 9);
@@ -72,12 +68,10 @@ const tests = {
       new Float32Array([0.1, 0.9, 0.3])
     );
 
-    const result3 = (
-      await zaplib.callRustAsync("array_multiply_f32_readonly", [
-        JSON.stringify(10),
-        input3,
-      ])
-    )[0] as Float32Array;
+    const [result3] = await zaplib.callRustAsync(
+      "array_multiply_f32_readonly",
+      [JSON.stringify(10), input3]
+    );
     expect(result3.length, 3);
     expect(result3[0], 1);
     expect(result3[1], 9);
@@ -86,10 +80,10 @@ const tests = {
   testCallRustAsyncSyncFloat32ArrayFromWorker: async () => {
     // Using a normal array
     const input = new Float32Array([0.1, 0.9, 0.3]);
-    const result = zaplib.callRustSync("array_multiply_f32", [
+    const [result] = zaplib.callRustSync("array_multiply_f32", [
       JSON.stringify(10),
       input,
-    ])[0] as Float32Array;
+    ]);
     expect(result.length, 3);
     expect(result[0], 1);
     expect(result[1], 9);
@@ -99,10 +93,10 @@ const tests = {
     const input2 = zaplib.createMutableBuffer(
       new Float32Array([0.1, 0.9, 0.3])
     );
-    const result2 = zaplib.callRustSync("array_multiply_f32", [
+    const [result2] = zaplib.callRustSync("array_multiply_f32", [
       JSON.stringify(10),
       input2,
-    ])[0] as Float32Array;
+    ]);
     expect(result2.length, 3);
     expect(result2[0], 1);
     expect(result2[1], 9);
@@ -113,10 +107,10 @@ const tests = {
       new Float32Array([0.1, 0.9, 0.3])
     );
 
-    const result3 = zaplib.callRustSync("array_multiply_f32_readonly", [
+    const [result3] = zaplib.callRustSync("array_multiply_f32_readonly", [
       JSON.stringify(10),
       input3,
-    ])[0] as Float32Array;
+    ]);
     expect(result3.length, 3);
     expect(result3[0], 1);
     expect(result3[1], 9);
@@ -161,10 +155,10 @@ rpc.receive("testSendZapArrayToMainThread", function () {
   const buffer = new SharedArrayBuffer(8);
   new Uint8Array(buffer).set([1, 2, 3, 4, 5, 6, 7, 8]);
   const uint8Part = new Uint8Array(buffer, 2, 4);
-  const zapArray = zaplib.callRustSync("array_multiply_u8", [
+  const [zapArray] = zaplib.callRustSync<[Uint8Array]>("array_multiply_u8", [
     JSON.stringify(10),
     uint8Part,
-  ])[0] as Uint8Array;
+  ]);
 
   return {
     array: zaplib.serializeZapArrayForPostMessage(zapArray),

--- a/zaplib/web/types.ts
+++ b/zaplib/web/types.ts
@@ -129,12 +129,14 @@ export type CreateBufferWorkerSync = <T extends ZapArray>(data: T) => T;
 
 export type CallJsCallback = (params: ZapParam[]) => void;
 
-export type CallRustAsync = (
+export type CallRustAsync = <T extends ZapParam[] = ZapParam[]>(
   name: string,
   params?: ZapParam[]
-) => Promise<ZapParam[]>;
+) => Promise<T>;
 
-export type CallRustSync = (...args: Parameters<CallRustAsync>) => ZapParam[];
+export type CallRustSync = <T extends ZapParam[] = ZapParam[]>(
+  ...args: Parameters<CallRustAsync>
+) => T;
 
 // Keep in sync with `param.rs`
 export enum ZapParamType {

--- a/zaplib/web/wasm_runtime.ts
+++ b/zaplib/web/wasm_runtime.ts
@@ -42,6 +42,7 @@ import {
   Initialize,
   WasmExports,
   IsInitialized,
+  ZapParam,
 } from "types";
 import { WebGLRenderer } from "webgl_renderer";
 import {
@@ -229,7 +230,10 @@ export const serializeZapArrayForPostMessage = (
   };
 };
 
-export const callRustAsync: CallRustAsync = async (name, params = []) => {
+export const callRustAsync: CallRustAsync = async <T extends ZapParam[]>(
+  name: string,
+  params: ZapParam[] = []
+): Promise<T> => {
   checkWasm();
 
   const transformedParams = params.map((param) => {
@@ -253,10 +257,13 @@ export const callRustAsync: CallRustAsync = async (name, params = []) => {
       name,
       params: transformedParams,
     })
-  );
+  ) as T;
 };
 
-export const callRustSync: CallRustSync = (name, params = []) =>
+export const callRustSync: CallRustSync = <T extends ZapParam[]>(
+  name: string,
+  params: ZapParam[] = []
+) =>
   callRustSyncImpl({
     name,
     params,
@@ -265,7 +272,7 @@ export const callRustSync: CallRustSync = (name, params = []) =>
     wasmExports,
     wasmAppPtr,
     transformParamsFromRust,
-  });
+  }) as T;
 
 export const createMutableBuffer: CreateBuffer = async (data) => {
   checkWasm();

--- a/zaplib/web/zaplib_worker_runtime.ts
+++ b/zaplib/web/zaplib_worker_runtime.ts
@@ -30,6 +30,7 @@ import {
   MutableBufferData,
   CreateBufferWorkerSync,
   IsInitialized,
+  ZapParam,
 } from "types";
 import { inWorker } from "type_of_runtime";
 import {
@@ -154,7 +155,10 @@ export const newWorkerPort = (): MessagePort => {
 };
 
 // TODO(JP): Allocate buffers on the wasm memory directly here.
-export const callRustAsync: CallRustAsync = async (name, params = []) => {
+export const callRustAsync: CallRustAsync = async <T extends ZapParam[]>(
+  name: string,
+  params: ZapParam[] = []
+) => {
   checkWasm();
 
   const transformedParams = params.map((param) => {
@@ -178,10 +182,13 @@ export const callRustAsync: CallRustAsync = async (name, params = []) => {
       name,
       params: transformedParams,
     })
-  );
+  ) as T;
 };
 
-export const callRustSync: CallRustSync = (name, params = []) =>
+export const callRustSync: CallRustSync = <T extends ZapParam[]>(
+  name: string,
+  params: ZapParam[] = []
+) =>
   callRustSyncImpl({
     name,
     params,
@@ -190,7 +197,7 @@ export const callRustSync: CallRustSync = (name, params = []) =>
     wasmExports,
     wasmAppPtr,
     transformParamsFromRust,
-  });
+  }) as T;
 
 // TODO(JP): See comment at CreateBufferWorkerSync type.
 export const createMutableBuffer: CreateBufferWorkerSync = (data) => {


### PR DESCRIPTION
By providing a generic here, we can let users specify expected param types
Fixes #129