### PR TITLE
properly nest tsconfig under compilerOptions

### DIFF
--- a/zaplib/docs/src/SUMMARY.md
+++ b/zaplib/docs/src/SUMMARY.md
@@ -44,6 +44,7 @@
 
 # Advanced
 - [Versioning](./versioning.md)
+- [TypeScript](./typescript.md)
 - [Jest Integration](./jest_integration.md)
 - [Webpack Integration](./webpack_integration.md)
 - [CEF](./cef.md)

--- a/zaplib/docs/src/developer_environment.md
+++ b/zaplib/docs/src/developer_environment.md
@@ -20,3 +20,7 @@ To get Rust source maps when doing local development in [Chrome](https://www.goo
 2. `Chrome DevTools > Settings (gear-icon ⚙ in top-right corner) > Experiments > WebAssembly Debugging: Enable DWARF support` ([More info](https://developer.chrome.com/blog/wasm-debugging-2020/))
 
 Note: these source maps read from hardcoded local file paths, so they'll only work on the computer that you've compiled on.
+
+# TypeScript
+
+Zaplib exports TypeScript types that should be picked up naturally. Check out the [TypeScript page of our docs](./typescript.md) for more information. 

--- a/zaplib/docs/src/typescript.md
+++ b/zaplib/docs/src/typescript.md
@@ -1,0 +1,9 @@
+# TypeScript
+
+Zaplib was written in TypeScript and exports TypeScript types.
+
+You may need to manually import the type declarations if you are directly using `zaplib.production.js` or `zaplib.development.js` -- which is how all the examples in these docs are setup to keep them simple (no webpack or other bundling). You can manually import the types via a [TypeScript reference](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html#-reference-types-):
+
+```ts
+/// <reference types="zaplib_runtime" />
+```

--- a/zaplib/web/package.json
+++ b/zaplib/web/package.json
@@ -3,6 +3,7 @@
     "version": "0.0.7",
     "license": "MIT",
     "main": "dist/zaplib_runtime.js",
+    "types:" : "dist/zaplib_runtime.d.ts",
     "files": [
         "dist"
     ],

--- a/zaplib/web/tsconfig.json
+++ b/zaplib/web/tsconfig.json
@@ -1,6 +1,4 @@
 {
-    "outDir": "./dist/",
-    "noImplicitAny": true,
     "compilerOptions": {
         "module": "es2020",
         "lib": [
@@ -10,8 +8,10 @@
         "target": "es6",
         "strict": true,
         "baseUrl": ".",
+        "declaration": true,
+        "noImplicitAny": true,
+        "outDir": "./dist/",
+        "sourceMap": true,   
+        "moduleResolution": "node"
     },
-    "sourceMap": true,
-    "allowJs": true,
-    "moduleResolution": "node"
 }


### PR DESCRIPTION
This PR was started to emit .d.ts files (https://github.com/Zaplib/zaplib/issues/116) but the solution involved fixing other issues with the tsconfig. Basically we were using attributes at the top level that should all be nested under `compilerOptions`.

Closes https://github.com/Zaplib/zaplib/issues/116