### PR TITLE
CEF -> Zapium in docs

### DIFF
--- a/zaplib/docs/src/SUMMARY.md
+++ b/zaplib/docs/src/SUMMARY.md
@@ -47,6 +47,6 @@
 - [TypeScript](./typescript.md)
 - [Jest Integration](./jest_integration.md)
 - [Webpack Integration](./webpack_integration.md)
-- [CEF](./cef.md)
+- [Zapium](./zapium.md)
 - [Known Issues](./known_issues.md)
 - [Contributing](./contributing.md)

--- a/zaplib/docs/src/bridge_api.md
+++ b/zaplib/docs/src/bridge_api.md
@@ -10,9 +10,9 @@ In production, similarly use: `zaplib_runtime.production.js` and `zaplib_worker_
 
 > Note: Zaplib performs some global setup upon import, notably modifying TypedArray implementations. We advise importing Zaplib first before other dependencies, so that all of your application code uses these modified values.
 
-Here is an overview of all the JS APIs, and their support with the WebAssembly runtime and the experimental [CEF](./cef.md) runtime.  Missing features are annotated with their ticket id.
+Here is an overview of all the JS APIs, and their support with the WebAssembly runtime and the experimental [Zapium](./zapium.md) runtime.  Missing features are annotated with their ticket id.
 
-| API                                         | Browser main thread | Browser Web Worker | [CEF](./cef.md) main thread | [CEF](./cef.md) Web Worker |
+| API                                         | Browser main thread | Browser Web Worker | [Zapium](./zapium.md) main thread | [Zapium](./zapium.md) Web Worker |
 | ------------------------------------------- | :---------------: | :---------------: | :--------------: | :--------------: |
 | zaplib.initialize                           |       ✅          |        n/a          |       ✅       |       n/a         |
 | zaplib.initializeWorker                     |      n/a          |        ✅          |       n/a       |    [#69][2] |

--- a/zaplib/docs/src/bridge_api_basics.md
+++ b/zaplib/docs/src/bridge_api_basics.md
@@ -29,7 +29,7 @@ This initializes the library. A couple of things happen:
 
 **Caveats**
 * Can only be called on the browser's main thread; in a worker use `zaplib.initializeWorker()`.
-* `wasmModule` is ignored in [CEF](./cef.md).
+* `wasmModule` is ignored in [Zapium](./zapium.md).
 * Call `zaplib.close` when you want to terminate all the Web Workers Zaplib opens. This can be useful when running tests.
 
 ## zaplib.callRustSync

--- a/zaplib/docs/src/bridge_api_params.md
+++ b/zaplib/docs/src/bridge_api_params.md
@@ -52,4 +52,4 @@ When a `u8` or `f32` buffer is returned to JS, you get a `ZapTypedArray`:
 
 When sending small amounts of data in either direction, we recommend simply JSON-serializing the data and sending it as a string. On the Rust side, [Serde](https://serde.rs/) is a fine library for this.
 
-Futher note that when using [CEF](./cef.md), data is often copied anyway, even when in the WebAssembly version it is not. This is one of the reasons why we do not recommend using [CEF](./cef.md) yet.
+Futher note that when using [Zapium](./zapium.md), data is often copied anyway, even when in the WebAssembly version it is not. This is one of the reasons why we do not recommend using [Zapium](./zapium.md) yet.

--- a/zaplib/docs/src/bridge_api_workers.md
+++ b/zaplib/docs/src/bridge_api_workers.md
@@ -3,7 +3,7 @@ Zaplib can also be used inside of your own Web Workers. This comes with both som
 
 First, include the Web Worker entry point (`zaplib_worker_runtime.development.js`).
 
-Note that when using [CEF](./cef.md) we don't support any of these functions yet.
+Note that when using [Zapium](./zapium.md) we don't support any of these functions yet.
 
 ## zaplib.newWorkerPort & zaplib.initializeWorker
 In order to use Zaplib inside Web Workers, we first have to create a "worker port" on the main thread, using `zaplib.newWorkerPort()`. Send that port to the Web Worker using whatever `postMessage` mechanism you already use. Be sure to add the port to the list of transferables. Example:

--- a/zaplib/docs/src/cef.md
+++ b/zaplib/docs/src/cef.md
@@ -1,6 +1,0 @@
-# Chromium Embedded Framework (CEF)
-
-Zaplib apps that include JavaScript can also target native builds by using the [Chromium Embedded Framework](https://bitbucket.org/chromiumembedded/cef/src/master/#markdown-header-introduction). This is Zaplib's equivalent of Electron. CEF runs the JavaScript. The Rust and rendering code are compiled natively (i.e. no WebAssembly or WebGL), which is generally more performant. 
-
-We do not recommend using this in production yet. It's currently mainly used to attach native debuggers and profilers. 
-

--- a/zaplib/docs/src/contributing.md
+++ b/zaplib/docs/src/contributing.md
@@ -39,7 +39,7 @@ cargo zaplib serve
 
 4. Click `Run All Tests`
 
-### Browser tests ([CEF](./cef.md))
+### Browser tests ([Zapium](./zapium.md))
 
 1. Install CEF (macOS Intel onl):
 

--- a/zaplib/docs/src/getting_started.md
+++ b/zaplib/docs/src/getting_started.md
@@ -17,7 +17,7 @@ cargo install cargo-zaplib
 cargo zaplib install-deps
 ```
 
-If you're going to do local development of Zaplib, be sue to add the `--devel` flag which installs some more dependencies, like [CEF](./cef.md) binaries.
+If you're going to do local development of Zaplib, be sue to add the `--devel` flag which installs some more dependencies, like [Zapium](./zapium.md) binaries.
 
 ```
 cargo zaplib install-deps --devel

--- a/zaplib/docs/src/introduction.md
+++ b/zaplib/docs/src/introduction.md
@@ -27,7 +27,7 @@ Zaplib supports the following build targets:
 2. **Mac OS X / Metal** - Tested on 11.6 Big Sur.
 3. **Linux / OpenGL** - Not well supported. Some APIs missing, but should run.
 4. **Windows / DirectX 11** - Currently broken... sorry!
-5. [**CEF**](./cef.md) - Zaplib's equivalent of Electron. Highly experimental.
+5. [**Zapium**](./zapium.html) - Zaplib's equivalent of Electron. Highly experimental.
 
 Currently our main focus is Web Assembly / WebGL support, and native targets are  mostly used for a faster development cycle. (Compiling Rust to native is faster than to WebAssembly.)
 ## Development

--- a/zaplib/docs/src/known_issues.md
+++ b/zaplib/docs/src/known_issues.md
@@ -26,7 +26,7 @@ Zaplib is still in its early days, and there are quite a few things to stabilize
 **OSX native**
 * Redrawing seems to leak a lot of memory.
 
-**OSX CEF**
+**OSX Zapium**
 * Stuck on old version (because we only got single process working on an old version).
 * Missing APIs compared to JS<=>Wasm bridge.
 * Too many memory copies.

--- a/zaplib/docs/src/zapium.md
+++ b/zaplib/docs/src/zapium.md
@@ -1,0 +1,9 @@
+# Zapium
+
+Zapium is the native, cross-platform Zaplib runtime. It converts Zaplib web apps to desktop apps, _where the Rust code runs natively, not via WebAssembly_.
+
+This is Zaplib's equivalent of Electron -- for an extra speed boost. Your JavaScript is run via the [Chromium Embedded Framework](https://bitbucket.org/chromiumembedded/cef/src/master/#markdown-header-introduction), and your Zaplib Rust & shader code is compiled natively (i.e. no WebAssembly or WebGL).
+
+Unlike the Zaplib WASM runtime which will always be free & fully open-source, Zapium will be commercially licensed and source-available.
+
+Contact us if you would like to use this in production.

--- a/zaplib/docs/src/zapium.md
+++ b/zaplib/docs/src/zapium.md
@@ -4,6 +4,6 @@ Zapium is the native, cross-platform Zaplib runtime. It converts Zaplib web apps
 
 This is Zaplib's equivalent of Electron -- for an extra speed boost. Your JavaScript is run via the [Chromium Embedded Framework](https://bitbucket.org/chromiumembedded/cef/src/master/#markdown-header-introduction), and your Zaplib Rust & shader code is compiled natively (i.e. no WebAssembly or WebGL).
 
-Unlike the Zaplib WASM runtime which will always be free & fully open-source, Zapium will be commercially licensed and source-available.
+Currently the Zapium code is open-source licensed just like all the other code in our repo, but we'll likely change Zapium's license in the near future to be commercially licensed and source-available.
 
 Contact us if you would like to use this in production.


### PR DESCRIPTION
Closes https://github.com/Zaplib/zaplib/issues/115

It seems like a much bigger, annoying project to actually rename this in the code. This PR just renames it in the docs, because that blocks us on evangelizing, while we can live with the code naming indefinitely. That ok?