### PR TITLE
Add support for Uint32Array as params when using wasm

### DIFF
--- a/zaplib/main/src/cef_browser.rs
+++ b/zaplib/main/src/cef_browser.rs
@@ -162,6 +162,8 @@ fn make_buffers_and_arc_ptrs(params: Vec<ZapParam>) -> V8Value {
             ZapParam::MutableU8Buffer(_) => ZAP_PARAM_UINT8_BUFFER,
             ZapParam::ReadOnlyF32Buffer(_) => ZAP_PARAM_READ_ONLY_FLOAT32_BUFFER,
             ZapParam::MutableF32Buffer(_) => ZAP_PARAM_FLOAT32_BUFFER,
+            ZapParam::ReadOnlyU32Buffer(_) => ZAP_PARAM_READ_ONLY_UINT32_BUFFER,
+            ZapParam::MutableU32Buffer(_) => ZAP_PARAM_UINT32_BUFFER,
         };
         let value = match param {
             ZapParam::String(str) => V8Value::create_string(&str),
@@ -169,6 +171,8 @@ fn make_buffers_and_arc_ptrs(params: Vec<ZapParam>) -> V8Value {
             ZapParam::MutableU8Buffer(buffer) => make_mutable_buffer(param_type, buffer),
             ZapParam::ReadOnlyF32Buffer(buffer) => make_readonly_buffer(param_type, buffer),
             ZapParam::MutableF32Buffer(buffer) => make_mutable_buffer(param_type, buffer),
+            ZapParam::ReadOnlyU32Buffer(buffer) => make_readonly_buffer(param_type, buffer),
+            ZapParam::MutableU32Buffer(buffer) => make_mutable_buffer(param_type, buffer),
         };
 
         values.set_value_byindex(index, &value);
@@ -211,6 +215,16 @@ fn get_zap_params(array: &V8Value) -> Vec<ZapParam> {
                     let callback =
                         array_buffer.get_array_buffer_release_callback::<MyV8ArrayBufferReleaseCallback<f32>>().unwrap();
                     Arc::clone(&callback.buffer).into_param()
+                }
+                ZAP_PARAM_READ_ONLY_UINT32_BUFFER => {
+                    let callback =
+                        array_buffer.get_array_buffer_release_callback::<MyV8ArrayBufferReleaseCallback<u32>>().unwrap();
+                    Arc::clone(&callback.buffer).into_param()
+                }
+                ZAP_PARAM_UINT32_BUFFER => {
+                    let callback =
+                        array_buffer.get_array_buffer_release_callback::<MyV8ArrayBufferReleaseCallback<u32>>().unwrap();
+                    callback.buffer.to_vec().into_param()
                 }
                 v => panic!("Invalid param type: {}", v),
             }

--- a/zaplib/main/src/cx_wasm32.rs
+++ b/zaplib/main/src/cx_wasm32.rs
@@ -867,6 +867,7 @@ pub unsafe extern "C" fn create_arc_vec(vec_ptr: u64, vec_len: u64, param_type: 
     match param_type as u32 {
         ZAP_PARAM_READ_ONLY_UINT8_BUFFER => create_arc_vec_inner::<u8>(vec_ptr, vec_len),
         ZAP_PARAM_READ_ONLY_FLOAT32_BUFFER => create_arc_vec_inner::<f32>(vec_ptr, vec_len),
+        ZAP_PARAM_READ_ONLY_UINT32_BUFFER => create_arc_vec_inner::<u32>(vec_ptr, vec_len),
         v => panic!("create_arc_vec: Invalid param type: {}", v),
     }
 }

--- a/zaplib/main/src/zerde.rs
+++ b/zaplib/main/src/zerde.rs
@@ -220,6 +220,12 @@ impl ZerdeBuilder {
                 ZapParam::MutableF32Buffer(buffer) => {
                     self.build_mutable_buffer(ZAP_PARAM_FLOAT32_BUFFER, buffer);
                 }
+                ZapParam::ReadOnlyU32Buffer(buffer) => {
+                    self.build_read_only_buffer(ZAP_PARAM_READ_ONLY_UINT32_BUFFER, buffer);
+                }
+                ZapParam::MutableU32Buffer(buffer) => {
+                    self.build_mutable_buffer(ZAP_PARAM_UINT32_BUFFER, buffer);
+                }
             }
         }
     }
@@ -343,8 +349,10 @@ impl ZerdeParser {
                     ZAP_PARAM_STRING => self.parse_string().into_param(),
                     ZAP_PARAM_READ_ONLY_UINT8_BUFFER => self.parse_arc_vec::<u8>().into_param(),
                     ZAP_PARAM_READ_ONLY_FLOAT32_BUFFER => self.parse_arc_vec::<f32>().into_param(),
+                    ZAP_PARAM_READ_ONLY_UINT32_BUFFER => self.parse_arc_vec::<u32>().into_param(),
                     ZAP_PARAM_UINT8_BUFFER => self.parse_buffer::<u8>().into_param(),
                     ZAP_PARAM_FLOAT32_BUFFER => self.parse_buffer::<f32>().into_param(),
+                    ZAP_PARAM_UINT32_BUFFER => self.parse_buffer::<u32>().into_param(),
                     value => panic!("Unexpected param type: {}", value),
                 }
             })

--- a/zaplib/web/cef_runtime.ts
+++ b/zaplib/web/cef_runtime.ts
@@ -153,6 +153,8 @@ const transformReturnParams = (returnParams: FromCefParams): ZapParam[] =>
         [ZapParamType.ReadOnlyU8Buffer]: Uint8Array,
         [ZapParamType.F32Buffer]: Float32Array,
         [ZapParamType.ReadOnlyF32Buffer]: Float32Array,
+        [ZapParamType.U32Buffer]: Uint32Array,
+        [ZapParamType.ReadOnlyU32Buffer]: Uint32Array,
       };
 
       // Creating array with stable identity as that's what underlying underlying API expects

--- a/zaplib/web/common.ts
+++ b/zaplib/web/common.ts
@@ -567,6 +567,9 @@ export function transformParamsFromRustImpl(
         [ZapParamType.ReadOnlyU8Buffer]: Uint8Array,
         [ZapParamType.F32Buffer]: Float32Array,
         [ZapParamType.ReadOnlyF32Buffer]: Float32Array,
+        [ZapParamType.U32Buffer]: Uint32Array,
+        [ZapParamType.ReadOnlyU32Buffer]: Uint32Array,
+
       }[param.paramType];
       return getCachedZapBuffer(
         zapBuffer,

--- a/zaplib/web/types.ts
+++ b/zaplib/web/types.ts
@@ -117,7 +117,7 @@ export type PostMessageTypedArray = {
   byteLength: number;
 };
 
-export type ZapArray = Uint8Array | Float32Array;
+export type ZapArray = Uint8Array | Float32Array | Uint32Array;
 export type ZapParam = ZapArray | string;
 export type RustZapParam = BufferData | string;
 
@@ -141,6 +141,8 @@ export enum ZapParamType {
   U8Buffer = 2,
   F32Buffer = 3,
   ReadOnlyF32Buffer = 4,
+  U32Buffer = 5,
+  ReadOnlyU32Buffer = 6,
 }
 
 export type SizingData = {

--- a/zaplib/web/zerde.ts
+++ b/zaplib/web/zerde.ts
@@ -220,6 +220,7 @@ export class ZerdeParser {
         params.push(this.parseString());
       } else if (
         paramType === ZapParamType.ReadOnlyU8Buffer ||
+        paramType === ZapParamType.ReadOnlyU32Buffer ||
         paramType === ZapParamType.ReadOnlyF32Buffer
       ) {
         const bufferPtr = this.parseU32();
@@ -235,6 +236,7 @@ export class ZerdeParser {
         });
       } else if (
         paramType === ZapParamType.U8Buffer ||
+        paramType === ZapParamType.U32Buffer ||
         paramType === ZapParamType.F32Buffer
       ) {
         const bufferPtr = this.parseU32();


### PR DESCRIPTION
Similarly to u8 and f32 arrays, this allows to send Uint32Array as parameters when communicating accross wasm boundaries