### PR TITLE
Disabling (unused) wasm demos to temporarily fix Heroku timeouts

### DIFF
--- a/zaplib/scripts/build_website_dev.sh
+++ b/zaplib/scripts/build_website_dev.sh
@@ -19,24 +19,23 @@ mdbook build zaplib/docs --dest-dir ../../website_dev/docs/
 # RUSTDOCFLAGS="-Dwarnings" so warnings are turned into errors.
 CARGO_TARGET_DIR="website_dev/target" RUSTDOCFLAGS="-Dwarnings" cargo doc --no-deps -p zaplib -p zaplib_components
 
-mkdir -p website_dev/zaplib/examples/example_bigedit/src/
-cp zaplib/examples/example_bigedit/src/treeworld.rs website_dev/zaplib/examples/example_bigedit/src/treeworld.rs
-
-cp zaplib/examples/example_bigedit/index.html website_dev/example_bigedit.html
-cp zaplib/examples/example_charts/index.html website_dev/example_charts.html
-cp zaplib/examples/example_lightning/index.html website_dev/example_lightning.html
-cp zaplib/examples/example_lots_of_buttons/index.html website_dev/example_lots_of_buttons.html
-cp zaplib/examples/example_shader/index.html website_dev/example_shader.html
-cp zaplib/examples/example_single_button/index.html website_dev/example_single_button.html
-cp zaplib/examples/example_text/index.html website_dev/example_text.html
-
-CARGO_TARGET_DIR="website_dev/target" cargo run -p cargo-zaplib -- build -p example_bigedit --release
-CARGO_TARGET_DIR="website_dev/target" cargo run -p cargo-zaplib -- build -p example_charts --release
-CARGO_TARGET_DIR="website_dev/target" cargo run -p cargo-zaplib -- build -p example_lightning --release
-CARGO_TARGET_DIR="website_dev/target" cargo run -p cargo-zaplib -- build -p example_lots_of_buttons --release
-CARGO_TARGET_DIR="website_dev/target" cargo run -p cargo-zaplib -- build -p example_shader --release
-CARGO_TARGET_DIR="website_dev/target" cargo run -p cargo-zaplib -- build -p example_single_button --release
-CARGO_TARGET_DIR="website_dev/target" cargo run -p cargo-zaplib -- build -p example_text --release
+# Disabling (unused) wasm demos to temporarily fix Heroku timeouts (https://github.com/Zaplib/zaplib/issues/141)
+# mkdir -p website_dev/zaplib/examples/example_bigedit/src/
+# cp zaplib/examples/example_bigedit/src/treeworld.rs website_dev/zaplib/examples/example_bigedit/src/treeworld.rs
+# cp zaplib/examples/example_bigedit/index.html website_dev/example_bigedit.html
+# cp zaplib/examples/example_charts/index.html website_dev/example_charts.html
+# cp zaplib/examples/example_lightning/index.html website_dev/example_lightning.html
+# cp zaplib/examples/example_lots_of_buttons/index.html website_dev/example_lots_of_buttons.html
+# cp zaplib/examples/example_shader/index.html website_dev/example_shader.html
+# cp zaplib/examples/example_single_button/index.html website_dev/example_single_button.html
+# cp zaplib/examples/example_text/index.html website_dev/example_text.html
+# CARGO_TARGET_DIR="website_dev/target" cargo run -p cargo-zaplib -- build -p example_bigedit --release
+# CARGO_TARGET_DIR="website_dev/target" cargo run -p cargo-zaplib -- build -p example_charts --release
+# CARGO_TARGET_DIR="website_dev/target" cargo run -p cargo-zaplib -- build -p example_lightning --release
+# CARGO_TARGET_DIR="website_dev/target" cargo run -p cargo-zaplib -- build -p example_lots_of_buttons --release
+# CARGO_TARGET_DIR="website_dev/target" cargo run -p cargo-zaplib -- build -p example_shader --release
+# CARGO_TARGET_DIR="website_dev/target" cargo run -p cargo-zaplib -- build -p example_single_button --release
+# CARGO_TARGET_DIR="website_dev/target" cargo run -p cargo-zaplib -- build -p example_text --release
 
 pushd zaplib/web/
     yarn

--- a/zaplib/scripts/build_website_prod.sh
+++ b/zaplib/scripts/build_website_prod.sh
@@ -20,11 +20,12 @@ cp -R website_dev/docs website/docs
 mkdir website/target
 cp -R website_dev/target/doc website/target/doc
 cp -R website_dev/*.html website/
-mkdir -p website/target/wasm32-unknown-unknown/release/
-cp website_dev/target/wasm32-unknown-unknown/release/*.wasm website/target/wasm32-unknown-unknown/release/
-mkdir -p website/zaplib/web/dist/
-cp website_dev/zaplib/web/dist/* website/zaplib/web/dist/
-mkdir -p website/zaplib/examples/example_bigedit/src/
-cp website_dev/zaplib/examples/example_bigedit/src/treeworld.rs website/zaplib/examples/example_bigedit/src/treeworld.rs
+# Disabling (unused) wasm demos to temporarily fix Heroku timeouts (https://github.com/Zaplib/zaplib/issues/141)
+# mkdir -p website/target/wasm32-unknown-unknown/release/
+# cp website_dev/target/wasm32-unknown-unknown/release/*.wasm website/target/wasm32-unknown-unknown/release/
+# mkdir -p website/zaplib/web/dist/
+# cp website_dev/zaplib/web/dist/* website/zaplib/web/dist/
+# mkdir -p website/zaplib/examples/example_bigedit/src/
+# cp website_dev/zaplib/examples/example_bigedit/src/treeworld.rs website/zaplib/examples/example_bigedit/src/treeworld.rs
 
 echo 'Website generated for publishing! Host using `cargo zaplib serve website/ --port 4848` or publish `website/`'


### PR DESCRIPTION
Workaround for https://github.com/Zaplib/zaplib/issues/141