### PR TITLE
Don’t screenshot “example_shader”

### DIFF
--- a/zaplib/ci/src/cmd.rs
+++ b/zaplib/ci/src/cmd.rs
@@ -267,7 +267,6 @@ async fn examples_screenshots(browser_name: &str, driver: &mut WebDriver, local_
         // ("example_charts", "example_charts/?release"), // TODO(JP): Randomness.
         // "example_lightning", // TODO(JP): Pause animation.
         ("example_lots_of_buttons", "example_lots_of_buttons/?release"),
-        ("example_shader", "example_shader/?release"),
         ("example_single_button", "example_single_button/?release"),
         ("example_text", "example_text/?release"),
         ("test_bottom_bar", "test_bottom_bar/?release"),
@@ -290,6 +289,9 @@ async fn examples_screenshots(browser_name: &str, driver: &mut WebDriver, local_
         ("tutorial_js_rust_bridge", "tutorial_js_rust_bridge"),
         ("tutorial_ui_components", "tutorial_ui_components"),
         ("tutorial_ui_layout", "tutorial_ui_layout"),
+        // This one has a bunch of non-deterministic GPU behavior and it doesn't
+        // really test anything that other examples don't already test.
+        // ("example_shader", "example_shader/?release"),
     ];
 
     for (example_name, example_path) in examples {

--- a/zaplib/scripts/ci/browser_tests.sh
+++ b/zaplib/scripts/ci/browser_tests.sh
@@ -22,7 +22,6 @@ cargo run -p cargo-zaplib -- build -p tutorial_ui_components
 cargo run -p cargo-zaplib -- build -p tutorial_ui_layout
 cargo run -p cargo-zaplib -- build --release -p example_charts
 cargo run -p cargo-zaplib -- build --release -p example_lots_of_buttons
-cargo run -p cargo-zaplib -- build --release -p example_shader
 cargo run -p cargo-zaplib -- build --release -p example_single_button
 cargo run -p cargo-zaplib -- build --release -p example_text
 cargo run -p cargo-zaplib -- build --release -p test_bottom_bar
@@ -30,6 +29,7 @@ cargo run -p cargo-zaplib -- build --release -p test_geometry
 cargo run -p cargo-zaplib -- build --release -p test_layout
 cargo run -p cargo-zaplib -- build --release -p test_padding
 cargo run -p cargo-zaplib -- build --release -p test_popover
+# cargo run -p cargo-zaplib -- build --release -p example_shader // See comment in `zaplib/ci/src/cmd.rs`
 
 # Build
 pushd zaplib/web

--- a/zaplib/scripts/ci/browser_tests_upload_screenshots.sh
+++ b/zaplib/scripts/ci/browser_tests_upload_screenshots.sh
@@ -11,7 +11,7 @@ cd "${0%/*}/../../.."
 # We use `--matchingThreshold` and `--thresholdPixel` because the GPU-rendered images come out slightly
 # different now and then. We suspect that this is because of differences in GPU hardware between
 # Browserstack runs.
-zaplib/web/node_modules/.bin/reg-cli screenshots/ previous_screenshots/ diff_screenshots/ --report ./index.html --json ./reg.json --ignoreChange --enableAntialias --matchingThreshold 0.15 --thresholdPixel 10
+zaplib/web/node_modules/.bin/reg-cli screenshots/ previous_screenshots/ diff_screenshots/ --report ./index.html --json ./reg.json --ignoreChange --enableAntialias --matchingThreshold 0.05 --thresholdPixel 3
 # Now let's bundle everything up in screenshots_report/
 mkdir screenshots_report/
 mv index.html screenshots_report/


### PR DESCRIPTION
Too much GPU nondeterminism in this shader.

This also allows us to tighten our comparison thresholds a bit. (Will
test this in CI)