### PR TITLE
Minor followup on example_image

### DIFF
--- a/zaplib/ci/src/cmd.rs
+++ b/zaplib/ci/src/cmd.rs
@@ -266,6 +266,7 @@ async fn examples_screenshots(browser_name: &str, driver: &mut WebDriver, local_
         // "example_bigedit/?release", // TODO(JP): Pause animation.
         // ("example_charts", "example_charts/?release"), // TODO(JP): Randomness.
         // "example_lightning", // TODO(JP): Pause animation.
+        ("example_image", "example_image/?release"),
         ("example_lots_of_buttons", "example_lots_of_buttons/?release"),
         ("example_single_button", "example_single_button/?release"),
         ("example_text", "example_text/?release"),

--- a/zaplib/examples/example_image/Cargo.toml
+++ b/zaplib/examples/example_image/Cargo.toml
@@ -6,4 +6,5 @@ publish = false
 
 [dependencies]
 zaplib = { path="../../main" }
+# TODO(JP): replace with Zaplib API; see https://github.com/Zaplib/zaplib/issues/161
 image = { version = "0.24.1", default-features = false, features=["jpeg"] }

--- a/zaplib/main/src/area.rs
+++ b/zaplib/main/src/area.rs
@@ -357,6 +357,8 @@ impl Area {
 
     /// Write a [`Texture`] value into the the [`DrawCall`] associated with this
     /// [`Area::InstanceRange`].
+    ///
+    /// TODO(JP): Fix bug: <https://github.com/Zaplib/zaplib/issues/156>
     pub fn write_texture_2d(&self, cx: &mut Cx, name: &str, texture_handle: TextureHandle) {
         if self.is_valid(cx) {
             if let Area::InstanceRange(inst) = self {

--- a/zaplib/scripts/ci/browser_tests.sh
+++ b/zaplib/scripts/ci/browser_tests.sh
@@ -21,6 +21,7 @@ cargo run -p cargo-zaplib -- build -p tutorial_js_rust_bridge
 cargo run -p cargo-zaplib -- build -p tutorial_ui_components
 cargo run -p cargo-zaplib -- build -p tutorial_ui_layout
 cargo run -p cargo-zaplib -- build --release -p example_charts
+cargo run -p cargo-zaplib -- build --release -p example_image
 cargo run -p cargo-zaplib -- build --release -p example_lots_of_buttons
 cargo run -p cargo-zaplib -- build --release -p example_single_button
 cargo run -p cargo-zaplib -- build --release -p example_text
@@ -29,7 +30,6 @@ cargo run -p cargo-zaplib -- build --release -p test_geometry
 cargo run -p cargo-zaplib -- build --release -p test_layout
 cargo run -p cargo-zaplib -- build --release -p test_padding
 cargo run -p cargo-zaplib -- build --release -p test_popover
-# cargo run -p cargo-zaplib -- build --release -p example_shader // See comment in `zaplib/ci/src/cmd.rs`
 
 # Build
 pushd zaplib/web


### PR DESCRIPTION
Some followup on https://github.com/Zaplib/zaplib/pull/159:
* Add a few TODOs for new tickets
* Flip the images so they render the right side up in wasm
* Add screenshot tests