### PR TITLE
Fix homepage navbar css

### DIFF
--- a/zaplib/website_root/index.html
+++ b/zaplib/website_root/index.html
@@ -28,19 +28,18 @@
   </head>
   <body>
     <div style="display: flex; flex-direction: column; max-width: 750px; padding: 20px; margin: auto;">
-      <div style="display: flex; justify-content: space-between;">
+      <div style="display: flex; justify-content: space-between; align-items: center;">
         <div style="font-size:x-large;">⚡️ Zaplib</div>
         <div style="font-size: medium;">
           <a style="margin-left: 8px; margin-right: 8px;" href="/docs">Docs</a>
           <a style="margin-left: 8px; margin-right: 8px;" href="/slack.html">Slack</a>
           <a style="margin-left: 8px; margin-right: 8px;" href="https://github.com/Zaplib/zaplib">Github</a>
-          <a style="margin-left: 8px; margin-right: 8px;" href="https://tinyletter.com/zaplib">Mailing list</a>
         </div>
       </div>
       <div style="display: flex; flex-direction: column; margin-top: 30px;">
         <div style="display: flex; flex-direction: column;">
           <div style="font-size: xx-large;"> 
-            Port your slow JavaScript to Rust, <em style="background: linear-gradient(90deg, rgba(14,36,0,1) 0%, rgba(1,107,161,1) 0%, rgba(48,199,198,1) 87%); -webkit-background-clip: text; -webkit-text-fill-color: transparent; padding-right: 1px;">incrementally</em>
+            Port your slow JavaScript to Rust, <em style="background: linear-gradient(90deg, rgba(14,36,0,1) 0%, rgba(1,107,161,1) 0%, rgba(48,199,198,1) 87%); background-clip: text; -webkit-text-fill-color: transparent; padding-right: 1px;">incrementally</em>
           </div>
           <div style="margin-top: 15px; line-height: 1.7;">
             Zaplib is a frontend framework that lets you rewrite the slow pieces of

--- a/zaplib/website_root/index.html
+++ b/zaplib/website_root/index.html
@@ -39,7 +39,7 @@
       <div style="display: flex; flex-direction: column; margin-top: 30px;">
         <div style="display: flex; flex-direction: column;">
           <div style="font-size: xx-large;"> 
-            Port your slow JavaScript to Rust, <em style="background: linear-gradient(90deg, rgba(14,36,0,1) 0%, rgba(1,107,161,1) 0%, rgba(48,199,198,1) 87%); background-clip: text; -webkit-text-fill-color: transparent; padding-right: 1px;">incrementally</em>
+            Port your slow JavaScript to Rust, <em style="background: linear-gradient(90deg, rgba(14,36,0,1) 0%, rgba(1,107,161,1) 0%, rgba(48,199,198,1) 87%); -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent; padding-right: 1px;">incrementally</em>
           </div>
           <div style="margin-top: 15px; line-height: 1.7;">
             Zaplib is a frontend framework that lets you rewrite the slow pieces of


### PR DESCRIPTION
I was showing off our website to someone IRL and it looked like:

![PXL_20220325_031759176](https://user-images.githubusercontent.com/2288939/160148287-0bea240a-1dcf-4c72-94d4-ca23512712fb.jpg)

The simplest answer was simply to drop the mailing list from the navbar:

<img width="368" alt="Screen Shot 2022-03-25 at 8 10 52 AM" src="https://user-images.githubusercontent.com/2288939/160148344-7bbf291b-b33c-4b5e-ad2f-98f1bdcd6337.png">

Made a couple other small css fixes