### PR TITLE
Add plausible analytics

### DIFF
--- a/zaplib/docs/theme/head.hbs
+++ b/zaplib/docs/theme/head.hbs
@@ -1,0 +1,1 @@
+<script defer data-domain="zaplib.com" src="https://plausible.io/js/plausible.js"></script>

--- a/zaplib/website_root/index.html
+++ b/zaplib/website_root/index.html
@@ -31,8 +31,8 @@
       <div style="display: flex; justify-content: space-between;">
         <div style="font-size:x-large;">⚡️ Zaplib</div>
         <div style="font-size: medium;">
-          <a style="margin-left: 8px; margin-right: 8px;" href="http://zaplib.com/docs">Docs</a>
-          <a style="margin-left: 8px; margin-right: 8px;" href="http://zaplib.com/slack.html">Slack</a>
+          <a style="margin-left: 8px; margin-right: 8px;" href="/docs">Docs</a>
+          <a style="margin-left: 8px; margin-right: 8px;" href="/slack.html">Slack</a>
           <a style="margin-left: 8px; margin-right: 8px;" href="https://github.com/Zaplib/zaplib">Github</a>
           <a style="margin-left: 8px; margin-right: 8px;" href="https://tinyletter.com/zaplib">Mailing list</a>
         </div>

--- a/zaplib/website_root/index.html
+++ b/zaplib/website_root/index.html
@@ -24,8 +24,8 @@
         line-height: 1.7;
       }
     </style>
+    <script defer data-domain="zaplib.com" src="https://plausible.io/js/plausible.js"></script>
   </head>
-
   <body>
     <div style="display: flex; flex-direction: column; max-width: 750px; padding: 20px; margin: auto;">
       <div style="display: flex; justify-content: space-between;">


### PR DESCRIPTION
I picked plausible because it came recommended and looks like a good privacy alternative to Google Analytics.

I don't know how to confirm that this works without pushing it to main, and then removing it if that doesn't work. On localhost, we get:

<img width="976" alt="Screen Shot 2022-03-25 at 8 46 51 AM" src="https://user-images.githubusercontent.com/2288939/160155091-5271d029-9781-46ab-bb00-f1ec823de745.png">

And on plausible:

<img width="480" alt="Screen Shot 2022-03-25 at 8 49 34 AM" src="https://user-images.githubusercontent.com/2288939/160155122-1799390c-e577-44cf-8ab9-e8332b126947.png">

@janpaul123 if you approve, let's merge it and see if it works, and I can remove it if not. I'm a bit worried about cross site stuff (with shared array buffers)