### PR TITLE
Disable text area for examples that don’t need it

### DIFF
--- a/zaplib/examples/example_charts/index.html
+++ b/zaplib/examples/example_charts/index.html
@@ -12,7 +12,7 @@
     <script type="text/javascript" src="/zaplib/web/dist/zaplib_runtime.development.js"></script>
     <script type="text/javascript">
         const env = new URL(window.document.location).searchParams.has("release") ? "release" : "debug";
-        zaplib.initialize({ wasmModule: `target/wasm32-unknown-unknown/${env}/example_charts.wasm`, defaultStyles: true });
+        zaplib.initialize({ wasmModule: `target/wasm32-unknown-unknown/${env}/example_charts.wasm`, defaultStyles: true, createTextArea: false });
     </script>
 </head>
 

--- a/zaplib/examples/example_flamegraph/index.html
+++ b/zaplib/examples/example_flamegraph/index.html
@@ -19,7 +19,7 @@ You may not use this file except in compliance with the License.
     <script type="text/javascript" src="/zaplib/web/dist/zaplib_runtime.development.js"></script>
     <script type="text/javascript">
         const env = new URL(window.document.location).searchParams.has("release") ? "release" : "debug";
-        zaplib.initialize({ wasmModule: `target/wasm32-unknown-unknown/${env}/example_flamegraph.wasm`, defaultStyles: true });
+        zaplib.initialize({ wasmModule: `target/wasm32-unknown-unknown/${env}/example_flamegraph.wasm`, defaultStyles: true, createTextArea: false });
     </script>
 </head>
 

--- a/zaplib/examples/example_image/index.html
+++ b/zaplib/examples/example_image/index.html
@@ -12,7 +12,7 @@
     <script type="text/javascript" src="/zaplib/web/dist/zaplib_runtime.development.js"></script>
     <script type="text/javascript">
         const env = new URL(window.document.location).searchParams.has("release") ? "release" : "debug";
-        zaplib.initialize({ wasmModule: `target/wasm32-unknown-unknown/${env}/example_image.wasm`, defaultStyles: true });
+        zaplib.initialize({ wasmModule: `target/wasm32-unknown-unknown/${env}/example_image.wasm`, defaultStyles: true, createTextArea: false });
     </script>
 </head>
 

--- a/zaplib/examples/example_lots_of_buttons/index.html
+++ b/zaplib/examples/example_lots_of_buttons/index.html
@@ -12,7 +12,7 @@
     <script type="text/javascript" src="/zaplib/web/dist/zaplib_runtime.development.js"></script>
     <script type="text/javascript">
         const env = new URL(window.document.location).searchParams.has("release") ? "release" : "debug";
-        zaplib.initialize({ wasmModule: `target/wasm32-unknown-unknown/${env}/example_lots_of_buttons.wasm`, defaultStyles: true });
+        zaplib.initialize({ wasmModule: `target/wasm32-unknown-unknown/${env}/example_lots_of_buttons.wasm`, defaultStyles: true, createTextArea: false });
     </script>
 </head>
 

--- a/zaplib/examples/example_shader/index.html
+++ b/zaplib/examples/example_shader/index.html
@@ -12,7 +12,7 @@
     <script type="text/javascript" src="/zaplib/web/dist/zaplib_runtime.development.js"></script>
     <script type="text/javascript">
         const env = new URL(window.document.location).searchParams.has("release") ? "release" : "debug";
-        zaplib.initialize({ wasmModule: `target/wasm32-unknown-unknown/${env}/example_shader.wasm`, defaultStyles: true });
+        zaplib.initialize({ wasmModule: `target/wasm32-unknown-unknown/${env}/example_shader.wasm`, defaultStyles: true, createTextArea: false });
     </script>
 </head>
 

--- a/zaplib/examples/example_single_button/index.html
+++ b/zaplib/examples/example_single_button/index.html
@@ -12,7 +12,7 @@
     <script type="text/javascript" src="/zaplib/web/dist/zaplib_runtime.development.js"></script>
     <script type="text/javascript">
         const env = new URL(window.document.location).searchParams.has("release") ? "release" : "debug";
-        zaplib.initialize({ wasmModule: `target/wasm32-unknown-unknown/${env}/example_single_button.wasm`, defaultStyles: true });
+        zaplib.initialize({ wasmModule: `target/wasm32-unknown-unknown/${env}/example_single_button.wasm`, defaultStyles: true, createTextArea: false });
     </script>
 </head>
 

--- a/zaplib/examples/example_text/index.html
+++ b/zaplib/examples/example_text/index.html
@@ -12,7 +12,7 @@
     <script type="text/javascript" src="/zaplib/web/dist/zaplib_runtime.development.js"></script>
     <script type="text/javascript">
         const env = new URL(window.document.location).searchParams.has("release") ? "release" : "debug";
-        zaplib.initialize({ wasmModule: `target/wasm32-unknown-unknown/${env}/example_text.wasm`, defaultStyles: true });
+        zaplib.initialize({ wasmModule: `target/wasm32-unknown-unknown/${env}/example_text.wasm`, defaultStyles: true, createTextArea: false });
     </script>
 </head>
 

--- a/zaplib/examples/test_geometry/index.html
+++ b/zaplib/examples/test_geometry/index.html
@@ -12,7 +12,7 @@
     <script type="text/javascript" src="/zaplib/web/dist/zaplib_runtime.development.js"></script>
     <script type="text/javascript">
         const env = new URL(window.document.location).searchParams.has("release") ? "release" : "debug";
-        zaplib.initialize({ wasmModule: `target/wasm32-unknown-unknown/${env}/test_geometry.wasm`, defaultStyles: true });
+        zaplib.initialize({ wasmModule: `target/wasm32-unknown-unknown/${env}/test_geometry.wasm`, defaultStyles: true, createTextArea: false });
     </script>
 </head>
 

--- a/zaplib/examples/test_layout/index.html
+++ b/zaplib/examples/test_layout/index.html
@@ -12,7 +12,7 @@
     <script type="text/javascript" src="/zaplib/web/dist/zaplib_runtime.development.js"></script>
     <script type="text/javascript">
         const env = new URL(window.document.location).searchParams.has("release") ? "release" : "debug";
-        zaplib.initialize({ wasmModule: `target/wasm32-unknown-unknown/${env}/test_layout.wasm`, defaultStyles: true });
+        zaplib.initialize({ wasmModule: `target/wasm32-unknown-unknown/${env}/test_layout.wasm`, defaultStyles: true, createTextArea: false });
     </script>
 </head>
 

--- a/zaplib/examples/test_many_quads/index.html
+++ b/zaplib/examples/test_many_quads/index.html
@@ -12,7 +12,7 @@
     <script type="text/javascript" src="/zaplib/web/dist/zaplib_runtime.development.js"></script>
     <script type="text/javascript">
         const env = new URL(window.document.location).searchParams.has("release") ? "release" : "debug";
-        zaplib.initialize({ wasmModule: `target/wasm32-unknown-unknown/${env}/test_many_quads.wasm`, defaultStyles: true });
+        zaplib.initialize({ wasmModule: `target/wasm32-unknown-unknown/${env}/test_many_quads.wasm`, defaultStyles: true, createTextArea: false });
     </script>
 </head>
 

--- a/zaplib/examples/test_multithread/index.html
+++ b/zaplib/examples/test_multithread/index.html
@@ -12,7 +12,7 @@
     <script type="text/javascript" src="/zaplib/web/dist/zaplib_runtime.development.js"></script>
     <script type="text/javascript">
         const env = new URL(window.document.location).searchParams.has("release") ? "release" : "debug";
-        zaplib.initialize({ wasmModule: `target/wasm32-unknown-unknown/${env}/test_multithread.wasm`, defaultStyles: true });
+        zaplib.initialize({ wasmModule: `target/wasm32-unknown-unknown/${env}/test_multithread.wasm`, defaultStyles: true, createTextArea: false });
     </script>
 </head>
 

--- a/zaplib/examples/test_padding/index.html
+++ b/zaplib/examples/test_padding/index.html
@@ -12,7 +12,7 @@
     <script type="text/javascript" src="/zaplib/web/dist/zaplib_runtime.development.js"></script>
     <script type="text/javascript">
         const env = new URL(window.document.location).searchParams.has("release") ? "release" : "debug";
-        zaplib.initialize({ wasmModule: `target/wasm32-unknown-unknown/${env}/test_padding.wasm`, defaultStyles: true });
+        zaplib.initialize({ wasmModule: `target/wasm32-unknown-unknown/${env}/test_padding.wasm`, defaultStyles: true, createTextArea: false });
     </script>
 </head>
 

--- a/zaplib/examples/test_popover/index.html
+++ b/zaplib/examples/test_popover/index.html
@@ -12,7 +12,7 @@
     <script type="text/javascript" src="/zaplib/web/dist/zaplib_runtime.development.js"></script>
     <script type="text/javascript">
         const env = new URL(window.document.location).searchParams.has("release") ? "release" : "debug";
-        zaplib.initialize({ wasmModule: `target/wasm32-unknown-unknown/${env}/test_popover.wasm`, defaultStyles: true });
+        zaplib.initialize({ wasmModule: `target/wasm32-unknown-unknown/${env}/test_popover.wasm`, defaultStyles: true, createTextArea: false });
     </script>
 </head>
 

--- a/zaplib/examples/test_shader_2d_primitives/index.html
+++ b/zaplib/examples/test_shader_2d_primitives/index.html
@@ -23,7 +23,7 @@
     <canvas id="myCanvas" width=601 height=601></canvas>
     <script>
         const env = new URL(window.document.location).searchParams.has("release") ? "release" : "debug";
-        zaplib.initialize({ wasmModule: `target/wasm32-unknown-unknown/${env}/test_shader_2d_primitives.wasm`, defaultStyles: true });
+        zaplib.initialize({ wasmModule: `target/wasm32-unknown-unknown/${env}/test_shader_2d_primitives.wasm`, defaultStyles: true, createTextArea: false });
 
         function draw_grid(cx, w, h, cell_size) {
             // Attempt to avoid antialising by offseting all drawing by half a pixel

--- a/zaplib/examples/tutorial_2d_rendering/step1/index.html
+++ b/zaplib/examples/tutorial_2d_rendering/step1/index.html
@@ -5,6 +5,6 @@
 <body>
     <script type="text/javascript" src="/zaplib/web/dist/zaplib_runtime.development.js"></script>
     <script type="text/javascript">
-        zaplib.initialize({ wasmModule: `target/wasm32-unknown-unknown/debug/tutorial_2d_rendering_step1.wasm`, defaultStyles: true });
+        zaplib.initialize({ wasmModule: `target/wasm32-unknown-unknown/debug/tutorial_2d_rendering_step1.wasm`, defaultStyles: true, createTextArea: false });
     </script>
 </body>

--- a/zaplib/examples/tutorial_2d_rendering/step2/index.html
+++ b/zaplib/examples/tutorial_2d_rendering/step2/index.html
@@ -5,6 +5,6 @@
 <body>
     <script type="text/javascript" src="/zaplib/web/dist/zaplib_runtime.development.js"></script>
     <script type="text/javascript">
-        zaplib.initialize({ wasmModule: `target/wasm32-unknown-unknown/debug/tutorial_2d_rendering_step2.wasm`, defaultStyles: true });
+        zaplib.initialize({ wasmModule: `target/wasm32-unknown-unknown/debug/tutorial_2d_rendering_step2.wasm`, defaultStyles: true, createTextArea: false });
     </script>
 </body>

--- a/zaplib/examples/tutorial_2d_rendering/step3/index.html
+++ b/zaplib/examples/tutorial_2d_rendering/step3/index.html
@@ -5,6 +5,6 @@
 <body>
     <script type="text/javascript" src="/zaplib/web/dist/zaplib_runtime.development.js"></script>
     <script type="text/javascript">
-        zaplib.initialize({ wasmModule: `target/wasm32-unknown-unknown/debug/tutorial_2d_rendering_step3.wasm`, defaultStyles: true });
+        zaplib.initialize({ wasmModule: `target/wasm32-unknown-unknown/debug/tutorial_2d_rendering_step3.wasm`, defaultStyles: true, createTextArea: false });
     </script>
 </body>

--- a/zaplib/examples/tutorial_3d_rendering/step3/index.js
+++ b/zaplib/examples/tutorial_3d_rendering/step3/index.js
@@ -1,1 +1,1 @@
-zaplib.initialize({ wasmModule: '/target/wasm32-unknown-unknown/debug/tutorial_3d_rendering_step3.wasm', defaultStyles: true });
+zaplib.initialize({ wasmModule: '/target/wasm32-unknown-unknown/debug/tutorial_3d_rendering_step3.wasm', defaultStyles: true, createTextArea: false });

--- a/zaplib/examples/tutorial_hello_thread/index.html
+++ b/zaplib/examples/tutorial_hello_thread/index.html
@@ -8,6 +8,7 @@
         zaplib.initialize({
             wasmModule: 'target/wasm32-unknown-unknown/debug/tutorial_hello_thread.wasm',
             defaultStyles: true,
+            createTextArea: false,
         });
     </script>
 </body>

--- a/zaplib/examples/tutorial_hello_world_canvas/index.html
+++ b/zaplib/examples/tutorial_hello_world_canvas/index.html
@@ -8,6 +8,7 @@
         zaplib.initialize({
             wasmModule: 'target/wasm32-unknown-unknown/debug/tutorial_hello_world_canvas.wasm',
             defaultStyles: true,
+            createTextArea: false,
         });
     </script>
 </body>

--- a/zaplib/examples/tutorial_ui_components/index.html
+++ b/zaplib/examples/tutorial_ui_components/index.html
@@ -5,6 +5,6 @@
 <body>
     <script type="text/javascript" src="/zaplib/web/dist/zaplib_runtime.development.js"></script>
     <script type="text/javascript">
-        zaplib.initialize({ wasmModule: `target/wasm32-unknown-unknown/debug/tutorial_ui_components.wasm`, defaultStyles: true });
+        zaplib.initialize({ wasmModule: `target/wasm32-unknown-unknown/debug/tutorial_ui_components.wasm`, defaultStyles: true, createTextArea: false });
     </script>
 </body>

--- a/zaplib/examples/tutorial_ui_layout/index.html
+++ b/zaplib/examples/tutorial_ui_layout/index.html
@@ -5,6 +5,6 @@
 <body>
     <script type="text/javascript" src="/zaplib/web/dist/zaplib_runtime.development.js"></script>
     <script type="text/javascript">
-        zaplib.initialize({ wasmModule: `target/wasm32-unknown-unknown/debug/tutorial_ui_layout.wasm`, defaultStyles: true });
+        zaplib.initialize({ wasmModule: `target/wasm32-unknown-unknown/debug/tutorial_ui_layout.wasm`, defaultStyles: true, createTextArea: false });
     </script>
 </body>

--- a/zaplib/web/cef_runtime.ts
+++ b/zaplib/web/cef_runtime.ts
@@ -1,5 +1,9 @@
 import { cursorMap } from "cursor_map";
-import { copyArrayToRustBuffer, getZapParamType } from "common";
+import {
+  copyArrayToRustBuffer,
+  getZapParamType,
+  normalizeInitParams,
+} from "common";
 import { makeTextarea, TextareaEvent } from "make_textarea";
 import {
   CallRustAsync,
@@ -200,6 +204,8 @@ export const isInitialized: IsInitialized = () => initialized;
 
 export const initialize: Initialize = (initParams) =>
   new Promise<void>((resolve) => {
+    initParams = normalizeInitParams(initParams);
+
     window.fromCefSetMouseCursor = (cursorId) => {
       if (document.body) {
         document.body.style.cursor = cursorMap[cursorId] || "default";
@@ -217,7 +223,7 @@ export const initialize: Initialize = (initParams) =>
         addDefaultStyles();
       }
 
-      if (initParams.createTextArea || initParams.defaultStyles) {
+      if (initParams.createTextArea) {
         const { showTextIME, textareaHasFocus } = makeTextarea(
           (taEvent: TextareaEvent) => {
             const slots = 20;

--- a/zaplib/web/common.ts
+++ b/zaplib/web/common.ts
@@ -6,6 +6,7 @@ import {
   CallRustSync,
   CreateBuffer,
   FileHandle,
+  InitParams,
   MutableBufferData,
   RustZapParam,
   TlsAndStackData,
@@ -724,3 +725,15 @@ export const createErrorCheckers = (
       }),
   };
 };
+
+export function normalizeInitParams(initParams: InitParams): InitParams {
+  const newInitParams: InitParams = { ...initParams };
+  if (
+    (newInitParams.createTextArea === undefined ||
+      newInitParams.createTextArea === null) &&
+    newInitParams.defaultStyles
+  ) {
+    newInitParams.createTextArea = true;
+  }
+  return newInitParams;
+}

--- a/zaplib/web/wasm_runtime.ts
+++ b/zaplib/web/wasm_runtime.ts
@@ -22,6 +22,7 @@ import {
   initTaskWorkerSab,
   initThreadLocalStorageMainWorker,
   makeThreadLocalStorageAndStackDataOnExistingThread,
+  normalizeInitParams,
   Rpc,
   transformParamsFromRustImpl,
 } from "common";
@@ -391,11 +392,7 @@ function initializeCanvas(
   const isMobileSafari = globalThis.navigator.platform.match(/iPhone|iPad/i);
   const isAndroid = globalThis.navigator.userAgent.match(/Android/i);
 
-  if (
-    !isMobileSafari &&
-    !isAndroid &&
-    (initParams.createTextArea || initParams.defaultStyles)
-  ) {
+  if (!isMobileSafari && !isAndroid && initParams.createTextArea) {
     // mobile keyboards are unusable on a UI like this
     const { showTextIME } = makeTextarea((taEvent: TextareaEvent) => {
       if (wasmInitialized()) {
@@ -502,6 +499,8 @@ export const isInitialized: IsInitialized = () => initialized;
 
 let alreadyCalledInitialize = false;
 export const initialize: Initialize = (initParams) => {
+  initParams = normalizeInitParams(initParams);
+
   if (alreadyCalledInitialize) {
     throw new Error("Only call zaplib.initialize() once");
   }


### PR DESCRIPTION
Apparently the focusing of the text area also causes stuff to jump
around like crazy in Firefox.

Fixes #193.